### PR TITLE
Adding skimage regionprops support to get_radial_distribution

### DIFF
--- a/src/cp_measure/fast/measureobjectintensitydistribution.py
+++ b/src/cp_measure/fast/measureobjectintensitydistribution.py
@@ -132,6 +132,9 @@ def get_radial_distribution(
         radius will be counted in an overflow bin. The radius is measured in pixels.
     """
 
+    if labels.dtype == bool:
+        labels = labels.astype(numpy.integer)
+
     unique_labels = numpy.unique(labels)
     nobjects = len(unique_labels[unique_labels>0])
     d_to_edge = centrosome.cpmorphology.distance_to_edge(labels)


### PR DESCRIPTION
Add labels type conversion to int if it is boolean. This adds compatibility with skimage's regionprops.
This fixes #2 