### PR TITLE
fix(radial_zernikes): update documentation, rm some TODOs

### DIFF
--- a/src/cp_measure/core/measureobjectintensitydistribution.py
+++ b/src/cp_measure/core/measureobjectintensitydistribution.py
@@ -305,16 +305,10 @@ def get_radial_zernikes(
     unique_labels = numpy.unique(labels)  # Will be used later for scipy.ndimage.sum
     unique_labels = unique_labels[unique_labels > 0]
     # MODIFIED: Delegate index generation to the minimum_enclosing_circle
-    # TODO: Check that this has the correct dimensions
-    ij = numpy.zeros((len(unique_labels) + 1, 2))
-    r = numpy.zeros((len(unique_labels) + 1))
     # MODIFIED: We assume non-overlapping labels for now
     # TODO Support label overlap (i.e., format in ijv)
     # MODIFIED: Delegate indexes to minimum_enclosing_circle
-    for index, _ in enumerate(unique_labels, 1):
-        ij_, r_ = centrosome.cpmorphology.minimum_enclosing_circle(labels, [index])
-        ij[[index]] = ij_
-        r[[index]] = r_
+    ij, r = centrosome.cpmorphology.minimum_enclosing_circle(labels, unique_labels)
 
     #
     # Then compute x and y, the position of each labeled pixel
@@ -322,10 +316,9 @@ def get_radial_zernikes(
     #
     ijv = masks_to_ijv(labels)
 
-    # MODIFIED: TODO double-check check that this -1 makes sense! `l` is used as indices later on
-    l_ = ijv[:, 2] - 1
+    l_ = ijv[:, 2]  # (N,1) vector with labels
 
-    yx = (ijv[:, :2] - ij[l_, :]) / r[l_, numpy.newaxis]
+    yx = (ijv[:, :2] - ij[l_ - 1, :]) / r[l_ - 1, numpy.newaxis]
 
     z = centrosome.zernike.construct_zernike_polynomials(
         yx[:, 1], yx[:, 0], zernike_indexes


### PR DESCRIPTION
This fixes some indexing that set radial zernikes 1 index off.

Code to check for NaNs and zeros:
```python 
import numpy as np
import pandas as pd
from cp_measure.bulk import get_core_measurements

# Create synthetic data
size = 200
rng = np.random.default_rng(42)
pixels = rng.integers(low=0, high=255, size=(size, size))

# Create two similar-sized objects
masks = np.zeros_like(pixels)
masks[50:100, 50:100] = 1  # First square 50x50
masks[110:160, 110:160] = 2  # Second square 50x50

# Get measurements
measurements = get_core_measurements()
results = {}

# Create a dictionary where each key is a feature
# and each value is a list of measurements (one per mask)
feature_dict = {}
for name, measurement_func in measurements.items():
    measurement_results = measurement_func(masks, pixels)
    feature_dict.update(measurement_results)

# Convert to DataFrame with mask numbers as index
df = pd.DataFrame(feature_dict)
import numpy as np
import pandas as pd
from cp_measure.bulk import get_core_measurements

# Create synthetic data
size = 200
rng = np.random.default_rng(42)
pixels = rng.integers(low=0, high=255, size=(size, size))

# Create two similar-sized objects
masks = np.zeros_like(pixels)
masks[50:100, 50:100] = 1  # First square 50x50
masks[110:160, 110:160] = 2  # Second square 50x50

# Get measurements
measurements = get_core_measurements()
results = {}

# Create a dictionary where each key is a feature
# and each value is a list of measurements (one per mask)
feature_dict = {}
for name, measurement_func in measurements.items():
    measurement_results = measurement_func(masks, pixels)
    feature_dict.update(measurement_results)

# Convert to DataFrame with mask numbers as index
df = pd.DataFrame(feature_dict)

```

Before fix:
![Screenshot 2025-03-10 at 1 35 35 PM](https://github.com/user-attachments/assets/9ad3a81f-91fc-4415-9eac-1978e0f6da69)

After fix:
![Screenshot 2025-03-10 at 2 32 19 PM](https://github.com/user-attachments/assets/0cb94885-0b67-433c-a391-58d3f8615d90)
