### PR TITLE
Relax numpy contraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scipy>=1.9.1",
     "centrosome>=1.3.1",
-    "numpy<2,>=1.22.1",
+    "numpy<3,>=1.22.1",
     "mahotas<2.0.0,>=1.4.13",
     "ruff>=0.12.1",
 ]


### PR DESCRIPTION
Trying to relax numpy constraint to allow `numpy>=2`.