### PR TITLE
fix(colocalization): Fix unexpected Macos+3.14 bug; reinstate CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - os: macos-latest
-            python-version: "3.14"
 
     steps:
       - uses: actions/checkout@v4

--- a/src/cp_measure/core/measurecolocalization.py
+++ b/src/cp_measure/core/measurecolocalization.py
@@ -154,6 +154,7 @@ def extract_pixels(
     fi = pixels_1[mask]
     si = pixels_2[mask]
     labels = mask.astype(numpy.uint32)[mask]
+    labels.setflags(write=False)
     lrange = numpy.arange(labels.max(), dtype=numpy.int32) + 1
     return fi, si, labels, lrange
 


### PR DESCRIPTION
Update the GitHub Actions workflow to include Python 3.14 on macOS. Additionally, set the labels array to read-only in the colocalization module to ensure data integrity.