### PR TITLE
feat(measure): Add global accelerator backend and dispatch

### DIFF
--- a/src/cp_measure/__init__.py
+++ b/src/cp_measure/__init__.py
@@ -1,4 +1,4 @@
-_VALID_ACCELERATORS = (None, "jax", "numba", "faster")
+_VALID_ACCELERATORS = (None, "jax", "numba", "fastest")
 _ACCELERATOR: str | None = None
 
 

--- a/src/cp_measure/__init__.py
+++ b/src/cp_measure/__init__.py
@@ -1,0 +1,11 @@
+_VALID_ACCELERATORS = (None, "jax", "numba", "faster")
+_ACCELERATOR: str | None = None
+
+
+def set_accelerator(backend: str | None) -> None:
+    if backend not in _VALID_ACCELERATORS:
+        raise ValueError(
+            f"unknown accelerator {backend!r}; expected one of {_VALID_ACCELERATORS}"
+        )
+    global _ACCELERATOR
+    _ACCELERATOR = backend

--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -34,7 +34,7 @@ _CORRELATION: dict[str, Callable] = {
 }
 
 # Default (None accelerator) registries. Optional backends (cp_measure.jax,
-# cp_measure.numba, "faster") will be wired into _dispatch when their sibling
+# cp_measure.numba, "fastest") will be wired into _dispatch when their sibling
 # packages exist; until then, selecting them raises NotImplementedError.
 _REGISTRIES: dict[str, dict[str, Callable]] = {
     "core": _CORE,
@@ -58,11 +58,11 @@ def _dispatch(name: str) -> dict[str, Callable]:
         raise NotImplementedError(
             f"'numba' accelerator not yet wired for {name} measurements"
         )
-    if _ACCELERATOR == "faster":
-        raise NotImplementedError("'faster' logic not yet implemented")
+    if _ACCELERATOR == "fastest":
+        raise NotImplementedError("'fastest' logic not yet implemented")
     raise ValueError(
         f"invalid accelerator {_ACCELERATOR!r}; "
-        "set via cp_measure.set_accelerator(None | 'jax' | 'numba' | 'faster')"
+        "set via cp_measure.set_accelerator(None | 'jax' | 'numba' | 'fastest')"
     )
 
 

--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -5,54 +5,75 @@ match the original names. This may change in the future.
 
 from typing import Callable
 
+from cp_measure.core import (
+    measurecolocalization,
+    measuregranularity,
+    measureobjectintensity,
+    measureobjectintensitydistribution,
+    measureobjectsizeshape,
+    measuretexture,
+)
+
+
+_CORE: dict[str, Callable] = {
+    "radial_distribution": measureobjectintensitydistribution.get_radial_distribution,
+    "radial_zernikes": measureobjectintensitydistribution.get_radial_zernikes,
+    "intensity": measureobjectintensity.get_intensity,
+    "sizeshape": measureobjectsizeshape.get_sizeshape,
+    "zernike": measureobjectsizeshape.get_zernike,
+    "feret": measureobjectsizeshape.get_feret,
+    "texture": measuretexture.get_texture,
+    "granularity": measuregranularity.get_granularity,
+}
+
+_CORRELATION: dict[str, Callable] = {
+    "costes": measurecolocalization.get_correlation_costes,
+    "pearson": measurecolocalization.get_correlation_pearson,
+    "manders_fold": measurecolocalization.get_correlation_manders_fold,
+    "rwc": measurecolocalization.get_correlation_rwc,
+}
+
+# Default (None accelerator) registries. Optional backends (cp_measure.jax,
+# cp_measure.numba, "faster") will be wired into _dispatch when their sibling
+# packages exist; until then, selecting them raises NotImplementedError.
+_REGISTRIES: dict[str, dict[str, Callable]] = {
+    "core": _CORE,
+    "correlation": _CORRELATION,
+}
+
+# 3D-capable subset of the core registry, by feature name.
+_3D_FEATURES = ("intensity", "sizeshape", "texture", "granularity")
+
+
+def _dispatch(name: str) -> dict[str, Callable]:
+    from cp_measure import _ACCELERATOR
+
+    if _ACCELERATOR is None:
+        return _REGISTRIES[name]
+    if _ACCELERATOR == "jax":
+        raise NotImplementedError(
+            f"'jax' accelerator not yet wired for {name} measurements"
+        )
+    if _ACCELERATOR == "numba":
+        raise NotImplementedError(
+            f"'numba' accelerator not yet wired for {name} measurements"
+        )
+    if _ACCELERATOR == "faster":
+        raise NotImplementedError("'faster' logic not yet implemented")
+
 
 def get_core_measurements() -> dict[str, Callable]:
-    from cp_measure.core import (
-        measuregranularity,
-        measureobjectintensity,
-        measureobjectintensitydistribution,
-        measureobjectsizeshape,
-        measuretexture,
-    )
-
-    return {
-        "radial_distribution": measureobjectintensitydistribution.get_radial_distribution,
-        "radial_zernikes": measureobjectintensitydistribution.get_radial_zernikes,
-        "intensity": measureobjectintensity.get_intensity,
-        "sizeshape": measureobjectsizeshape.get_sizeshape,
-        "zernike": measureobjectsizeshape.get_zernike,
-        "feret": measureobjectsizeshape.get_feret,
-        "texture": measuretexture.get_texture,
-        "granularity": measuregranularity.get_granularity,
-    }
+    return _dispatch("core")
 
 
 def get_core_measurements_3d() -> dict[str, Callable]:
     """Return only measurements that support 3D input."""
-    from cp_measure.core import (
-        measuregranularity,
-        measureobjectintensity,
-        measureobjectsizeshape,
-        measuretexture,
-    )
-
-    return {
-        "intensity": measureobjectintensity.get_intensity,
-        "sizeshape": measureobjectsizeshape.get_sizeshape,
-        "texture": measuretexture.get_texture,
-        "granularity": measuregranularity.get_granularity,
-    }
+    core = _dispatch("core")
+    return {k: core[k] for k in _3D_FEATURES}
 
 
 def get_correlation_measurements() -> dict[str, Callable]:
-    from cp_measure.core import measurecolocalization
-
-    return {
-        "costes": measurecolocalization.get_correlation_costes,
-        "pearson": measurecolocalization.get_correlation_pearson,
-        "manders_fold": measurecolocalization.get_correlation_manders_fold,
-        "rwc": measurecolocalization.get_correlation_rwc,
-    }
+    return _dispatch("correlation")
 
 
 def get_multimask_measurements() -> dict[str, Callable]:

--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -60,6 +60,10 @@ def _dispatch(name: str) -> dict[str, Callable]:
         )
     if _ACCELERATOR == "faster":
         raise NotImplementedError("'faster' logic not yet implemented")
+    raise ValueError(
+        f"invalid accelerator {_ACCELERATOR!r}; "
+        "set via cp_measure.set_accelerator(None | 'jax' | 'numba' | 'faster')"
+    )
 
 
 def get_core_measurements() -> dict[str, Callable]:

--- a/src/cp_measure/utils.py
+++ b/src/cp_measure/utils.py
@@ -49,12 +49,12 @@ def masks_to_ijv(masks: numpy.ndarray) -> numpy.ndarray:
     return masks_ijv
 
 
-def labels_to_binmasks(masks: numpy.ndarray) -> list:
+def labels_to_binmasks(masks: numpy.ndarray) -> numpy.ndarray:
     """
     Convert a label matrix to a boolean masks.
 
     Returns a list of binary masks.
     """
     labels = numpy.unique(masks)
-    labels = sorted(labels[labels > 0])
-    return [(masks == i) for i in labels]
+    labels = labels[labels > 0]
+    return masks == labels.reshape((-1,) + (1,) * masks.ndim)


### PR DESCRIPTION
Introduce a global accelerator backend mechanism via `set_accelerator()` in `cp_measure.__init__`. Bulk measurement functions now use an internal `_dispatch()` mechanism to return implementations based on the selected
accelerator. Accelerator-specific implementations are not yet wired.

@timtreis Turns out you actually call my dispatcher get_core_measurements and the other ones in the featurizer, so I made that the place we use to dispatch the final functions.