### PR TITLE
Intensity/sizeshape/colocalisation Speedups

### DIFF
--- a/src/cp_measure/core/measurecolocalization.py
+++ b/src/cp_measure/core/measurecolocalization.py
@@ -78,17 +78,13 @@ References
 .. _here: https://jcs.biologists.org/content/joces/131/3/jcs211847.full.pdf
 """
 
-from functools import partial
-from typing import Callable
+from typing import Iterator
 
 import numpy
 from numpy.typing import NDArray
 import scipy.ndimage
 import scipy.stats
-from cp_measure.utils import _ensure_np_array as fix
 from scipy.linalg import lstsq
-
-from cp_measure.utils import labels_to_binmasks
 
 M_IMAGES = "Across entire image"
 M_OBJECTS = "Within objects"
@@ -127,27 +123,165 @@ F_COSTES_FORMAT = "Correlation_Costes"
 """
 thr : int or float, optional
     Set threshold as percentage of maximum intensity for the images (default 15).
-    You may choose to measure colocalization metrics only for those pixels above 
-    a certain threshold. Select the threshold as a percentage of the maximum intensity 
+    You may choose to measure colocalization metrics only for those pixels above
+    a certain threshold. Select the threshold as a percentage of the maximum intensity
     of the above image [0-99].
-    This value is used by the Overlap, Manders, and Rank Weighted Colocalization 
+    This value is used by the Overlap, Manders, and Rank Weighted Colocalization
     measurements.
 
 fast_costes : {M_FASTER, M_FAST, M_ACCURATE}, optional
     Method for Costes thresholding (default M_FASTER).
     This setting determines the method used to calculate the threshold for use within the
     Costes calculations. The *{M_FAST}* and *{M_ACCURATE}* modes will test candidate thresholds
-    in descending order until the optimal threshold is reached. Selecting *{M_FAST}* will attempt 
-    to skip candidates when results are far from the optimal value being sought. Selecting *{M_ACCURATE}* 
-    will test every possible threshold value. When working with 16-bit images these methods can be extremely 
-    time-consuming. Selecting *{M_FASTER}* will use a modified bisection algorithm to find the threshold 
-    using a shrinking window of candidates. This is substantially faster but may produce slightly lower 
+    in descending order until the optimal threshold is reached. Selecting *{M_FAST}* will attempt
+    to skip candidates when results are far from the optimal value being sought. Selecting *{M_ACCURATE}*
+    will test every possible threshold value. When working with 16-bit images these methods can be extremely
+    time-consuming. Selecting *{M_FASTER}* will use a modified bisection algorithm to find the threshold
+    using a shrinking window of candidates. This is substantially faster but may produce slightly lower
     thresholds in exceptional circumstances.
-    In the vast majority of instances the results of all strategies should be identical. We recommend using 
+    In the vast majority of instances the results of all strategies should be identical. We recommend using
     *{M_FAST}* mode when working with 8-bit images and *{M_FASTER}* mode when using 16-bit images.
-    Alternatively, you may want to disable these specific measurements entirely 
+    Alternatively, you may want to disable these specific measurements entirely
     (available when "*Run All Metrics?*" is set to "*No*").
 """
+
+
+# ---------------------------------------------------------------------------
+# Per-pair primitives (operate on already-extracted 1D pixel arrays)
+# ---------------------------------------------------------------------------
+
+
+def _pearson_pair(
+    fi: NDArray[numpy.floating], si: NDArray[numpy.floating]
+) -> tuple[float, float]:
+    corr = numpy.corrcoef(fi, si)[0, 1]
+    coeffs = lstsq(numpy.array((fi, numpy.ones_like(fi))).transpose(), si)[0]
+    return float(corr), float(coeffs[0])
+
+
+def _manders_pair(
+    fi: NDArray[numpy.floating], si: NDArray[numpy.floating], thr: float
+) -> tuple[float, float]:
+    tff = (thr / 100) * fi.max()
+    tss = (thr / 100) * si.max()
+    combined = (fi >= tff) & (si >= tss)
+    if not combined.any():
+        return 0.0, 0.0
+    tot_fi = fi[fi >= tff].sum()
+    tot_si = si[si >= tss].sum()
+    # Match historical behaviour: when tot is 0, propagate NaN.
+    with numpy.errstate(invalid="ignore", divide="ignore"):
+        M1 = float(fi[combined].sum() / tot_fi)
+        M2 = float(si[combined].sum() / tot_si)
+    return M1, M2
+
+
+def _overlap_pair(
+    fi: NDArray[numpy.floating], si: NDArray[numpy.floating], thr: float
+) -> tuple[float, float, float]:
+    tff = (thr / 100) * fi.max()
+    tss = (thr / 100) * si.max()
+    combined = (fi >= tff) & (si >= tss)
+    if not combined.any():
+        return 0.0, 0.0, 0.0
+    fi_t = fi[combined]
+    si_t = si[combined]
+    fpsq = float(numpy.sum(fi_t * fi_t))
+    spsq = float(numpy.sum(si_t * si_t))
+    prod = float(numpy.sum(fi_t * si_t))
+    pdt = numpy.sqrt(fpsq * spsq)
+    with numpy.errstate(invalid="ignore", divide="ignore"):
+        overlap = prod / pdt
+        K1 = prod / fpsq
+        K2 = prod / spsq
+    return overlap, K1, K2
+
+
+def _rwc_pair(
+    fi: NDArray[numpy.floating], si: NDArray[numpy.floating], thr: float
+) -> tuple[float, float]:
+    Rank1 = numpy.lexsort([fi])
+    Rank2 = numpy.lexsort([si])
+    Rank1_U = numpy.hstack([[False], fi[Rank1[:-1]] != fi[Rank1[1:]]])
+    Rank2_U = numpy.hstack([[False], si[Rank2[:-1]] != si[Rank2[1:]]])
+    Rank1_S = numpy.cumsum(Rank1_U)
+    Rank2_S = numpy.cumsum(Rank2_U)
+    Rank_im1 = numpy.zeros(fi.shape, dtype=int)
+    Rank_im2 = numpy.zeros(si.shape, dtype=int)
+    Rank_im1[Rank1] = Rank1_S
+    Rank_im2[Rank2] = Rank2_S
+
+    R = max(Rank_im1.max(), Rank_im2.max()) + 1
+    Di = abs(Rank_im1 - Rank_im2)
+    weight = (R - Di) * 1.0 / R
+
+    tff = (thr / 100) * fi.max()
+    tss = (thr / 100) * si.max()
+    combined = (fi >= tff) & (si >= tss)
+    if not combined.any():
+        return 0.0, 0.0
+    fi_t = fi[combined]
+    si_t = si[combined]
+    w_t = weight[combined]
+    tot_fi = fi[fi >= tff].sum()
+    tot_si = si[si >= tss].sum()
+    with numpy.errstate(invalid="ignore", divide="ignore"):
+        RWC1 = float((fi_t * w_t).sum() / tot_fi)
+        RWC2 = float((si_t * w_t).sum() / tot_si)
+    return RWC1, RWC2
+
+
+def _costes_pair(
+    fi: NDArray[numpy.floating],
+    si: NDArray[numpy.floating],
+    scale: int,
+    fast_costes: str,
+) -> tuple[float, float]:
+    if fast_costes == M_FASTER:
+        thr_fi, thr_si = bisection_costes(None, None, fi, si, scale, fast_costes)
+    else:
+        thr_fi, thr_si = linear_costes(None, None, fi, si, scale, fast_costes)
+    fi_above = fi > thr_fi
+    si_above = si > thr_si
+    combined = fi_above & si_above
+    if not combined.any():
+        return 0.0, 0.0
+    tot_fi = fi[fi >= thr_fi].sum()
+    tot_si = si[si >= thr_si].sum()
+    with numpy.errstate(invalid="ignore", divide="ignore"):
+        C1 = float(fi[combined].sum() / tot_fi)
+        C2 = float(si[combined].sum() / tot_si)
+    return C1, C2
+
+
+# ---------------------------------------------------------------------------
+# Per-label pixel iteration using find_objects (bounding box slicing)
+# ---------------------------------------------------------------------------
+
+
+def _iter_label_pixels(
+    pixels_1: NDArray[numpy.floating],
+    pixels_2: NDArray[numpy.floating],
+    masks: NDArray[numpy.integer],
+) -> Iterator[
+    tuple[NDArray[numpy.floating], NDArray[numpy.floating]] | tuple[None, None]
+]:
+    """Yield (fi, si) per label using bounding boxes; (None, None) for empty labels."""
+    objects = scipy.ndimage.find_objects(masks)
+    for label_idx, sl in enumerate(objects, start=1):
+        if sl is None:
+            yield None, None
+            continue
+        local = masks[sl] == label_idx
+        fi = pixels_1[sl][local]
+        si = pixels_2[sl][local]
+        yield fi, si
+
+
+# ---------------------------------------------------------------------------
+# Public single-mask (binary) entry points — kept for API compatibility.
+# These accept a boolean mask and return scalar features for that single object.
+# ---------------------------------------------------------------------------
 
 
 def extract_pixels(
@@ -163,54 +297,14 @@ def extract_pixels(
     return fi, si, labels, lrange
 
 
-def calculate_threshold(
-    pixels_1: NDArray[numpy.floating],
-    pixels_2: NDArray[numpy.floating],
-    mask: NDArray[numpy.integer],
-    thr: int,
-) -> tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]:
-    # Threshold as percentage of maximum intensity of objects in each channel
-    first_pixels, second_pixels, labels, lrange = extract_pixels(
-        pixels_1, pixels_2, mask
-    )
-    tff = (thr / 100) * fix(scipy.ndimage.maximum(first_pixels, labels, lrange))
-    tss = (thr / 100) * fix(scipy.ndimage.maximum(second_pixels, labels, lrange))
-    combined_thresh = (first_pixels >= tff[labels - 1]) & (
-        second_pixels >= tss[labels - 1]
-    )
-    fi_thresh = first_pixels[combined_thresh]
-    si_thresh = second_pixels[combined_thresh]
-    tot_fi_thr = scipy.ndimage.sum(
-        first_pixels[first_pixels >= tff[labels - 1]],
-        labels[first_pixels >= tff[labels - 1]],
-        lrange,
-    )
-    tot_si_thr = scipy.ndimage.sum(
-        second_pixels[second_pixels >= tss[labels - 1]],
-        labels[second_pixels >= tss[labels - 1]],
-        lrange,
-    )
-    return fi_thresh, si_thresh, tot_fi_thr, tot_si_thr, combined_thresh
-
-
 def get_correlation_pearson_ind(
     pixels_1: NDArray[numpy.floating],
     pixels_2: NDArray[numpy.floating],
     mask: NDArray[numpy.integer],
 ) -> dict[str, float]:
-    fi, si, _, _ = extract_pixels(pixels_1, pixels_2, mask)
-    #
-    # Perform the correlation, which returns:
-    # [ [ii, ij],
-    #   [ji, jj] ]
-    #
-    corr = numpy.corrcoef((fi, si))[1, 0]
-    #
-    # Find the slope as a linear regression to
-    # A * i1 + B = i2
-    #
-    coeffs = lstsq(numpy.array((fi, numpy.ones_like(fi))).transpose(), si)[0]
-    slope = coeffs[0]
+    fi = pixels_1[mask]
+    si = pixels_2[mask]
+    corr, slope = _pearson_pair(fi, si)
     return {F_CORRELATION_FORMAT: corr, F_SLOPE_FORMAT: slope}
 
 
@@ -220,31 +314,10 @@ def get_correlation_manders_fold_ind(
     mask: NDArray[numpy.integer],
     thr: int = 15,
 ) -> dict[str, float]:
-    first_pixels, second_pixels, labels, lrange = extract_pixels(
-        pixels_1, pixels_2, mask
-    )
-    fi_thresh, si_thresh, tot_fi_thr, tot_si_thr, combined_thresh = calculate_threshold(
-        pixels_1, pixels_2, mask, thr
-    )
-    # Manders Coefficient
-    M1 = 0.0
-    M2 = 0.0
-    if combined_thresh.any():
-        M1 = numpy.array(
-            scipy.ndimage.sum(fi_thresh, labels[combined_thresh], lrange)
-        ) / numpy.array(tot_fi_thr)
-        M2 = numpy.array(
-            scipy.ndimage.sum(si_thresh, labels[combined_thresh], lrange)
-        ) / numpy.array(tot_si_thr)
-
-        # TODO remove this to support multiple labels
-        M1 = M1[0]
-        M2 = M2[0]
-
-    return {
-        f"{F_MANDERS_FORMAT}_1": M1,
-        f"{F_MANDERS_FORMAT}_2": M2,
-    }
+    fi = pixels_1[mask]
+    si = pixels_2[mask]
+    M1, M2 = _manders_pair(fi, si, thr)
+    return {f"{F_MANDERS_FORMAT}_1": M1, f"{F_MANDERS_FORMAT}_2": M2}
 
 
 def get_correlation_rwc_ind(
@@ -253,60 +326,10 @@ def get_correlation_rwc_ind(
     mask: NDArray[numpy.integer],
     thr: int = 15,
 ) -> dict[str, float]:
-    first_pixels, second_pixels, labels, lrange = extract_pixels(
-        pixels_1, pixels_2, mask
-    )
-    fi_thresh, si_thresh, tot_fi_thr, tot_si_thr, combined_thresh = calculate_threshold(
-        pixels_1, pixels_2, mask, thr
-    )
-
-    # RWC Coefficient
-    [Rank1] = numpy.lexsort(([labels], [first_pixels]))
-    [Rank2] = numpy.lexsort(([labels], [second_pixels]))
-    Rank1_U = numpy.hstack(
-        [
-            [False],
-            first_pixels[Rank1[:-1]] != first_pixels[Rank1[1:]],
-        ]
-    )
-    Rank2_U = numpy.hstack(
-        [
-            [False],
-            second_pixels[Rank2[:-1]] != second_pixels[Rank2[1:]],
-        ]
-    )
-    Rank1_S = numpy.cumsum(Rank1_U)
-    Rank2_S = numpy.cumsum(Rank2_U)
-    Rank_im1 = numpy.zeros(first_pixels.shape, dtype=int)
-    Rank_im2 = numpy.zeros(second_pixels.shape, dtype=int)
-    Rank_im1[Rank1] = Rank1_S
-    Rank_im2[Rank2] = Rank2_S
-
-    R = max(Rank_im1.max(), Rank_im2.max()) + 1
-    Di = abs(Rank_im1 - Rank_im2)
-    weight = (R - Di) * 1.0 / R
-    weight_thresh = weight[combined_thresh]
-
-    RWC1: float | numpy.ndarray = 0.0
-    RWC2: float | numpy.ndarray = 0.0
-    if combined_thresh.any():  # TODO adjust this to support multiple labels
-        RWC1 = numpy.array(
-            scipy.ndimage.sum(
-                fi_thresh * weight_thresh, labels[combined_thresh], lrange
-            )
-        ) / numpy.array(tot_fi_thr)
-        RWC2 = numpy.array(
-            scipy.ndimage.sum(
-                si_thresh * weight_thresh, labels[combined_thresh], lrange
-            )
-        ) / numpy.array(tot_si_thr)
-        RWC1 = RWC1[0]  # type: ignore[index]
-        RWC2 = RWC2[0]  # type: ignore[index]
-
-    return {
-        f"{F_RWC_FORMAT}_1": RWC1,  # type: ignore[dict-item]
-        f"{F_RWC_FORMAT}_2": RWC2,  # type: ignore[dict-item]
-    }
+    fi = pixels_1[mask]
+    si = pixels_2[mask]
+    RWC1, RWC2 = _rwc_pair(fi, si, thr)
+    return {f"{F_RWC_FORMAT}_1": RWC1, f"{F_RWC_FORMAT}_2": RWC2}
 
 
 def get_correlation_costes_ind(
@@ -316,70 +339,38 @@ def get_correlation_costes_ind(
     fast_costes: str = M_FASTER,
     thr: int = 15,
 ) -> dict[str, float]:
-    # Orthogonal Regression for Costes' automated threshold
-    first_pixels, second_pixels, labels, lrange = extract_pixels(
-        pixels_1, pixels_2, mask
-    )
-    fi_thresh, si_thresh, tot_fi_thr, tot_si_thr, combined_thresh = calculate_threshold(
-        pixels_1, pixels_2, mask, thr
-    )
-    # MODIFIED: Removed the section that combines both images
-    # MODIFIED: Added dimension because algorithms expect fi,si to be 3D
+    fi = pixels_1[mask]
+    si = pixels_2[mask]
     scale = infer_scale(pixels_1)
-    if fast_costes == M_FASTER:
-        thr_fi_c, thr_si_c = bisection_costes(
-            pixels_1, pixels_2, first_pixels, second_pixels, scale, fast_costes
-        )
-    else:
-        thr_fi_c, thr_si_c = linear_costes(
-            pixels_1, pixels_2, first_pixels, second_pixels, scale
-        )
+    C1, C2 = _costes_pair(fi, si, scale, fast_costes)
+    return {f"{F_COSTES_FORMAT}_1": C1, f"{F_COSTES_FORMAT}_2": C2}
 
-    # Costes' thershold for entire image is applied to each object
-    fi_above_thr = first_pixels > thr_fi_c
-    si_above_thr = second_pixels > thr_si_c
-    combined_thresh_c = fi_above_thr & si_above_thr
-    fi_thresh_c = first_pixels[combined_thresh_c]
-    si_thresh_c = second_pixels[combined_thresh_c]
 
-    tot_fi_thr_c = numpy.zeros(len(lrange))
-    tot_si_thr_c = numpy.zeros(len(lrange))
-
-    if numpy.any(fi_above_thr):
-        tot_fi_thr_c = scipy.ndimage.sum(
-            first_pixels[first_pixels >= thr_fi_c],
-            labels[first_pixels >= thr_fi_c],
-            lrange,
-        )
-
-    if numpy.any(si_above_thr):
-        tot_si_thr_c = scipy.ndimage.sum(
-            second_pixels[second_pixels >= thr_si_c],
-            labels[second_pixels >= thr_si_c],
-            lrange,
-        )
-
-    # Costes Automated Threshold
-    C1: list[float] | numpy.ndarray
-    C2: list[float] | numpy.ndarray
-    C1, C2 = [0.0], [0.0]  # Cover fringe case of no pixels above threshold
-    if len(fi_thresh_c) and len(si_thresh_c):
-        C1 = numpy.array(
-            scipy.ndimage.sum(fi_thresh_c, labels[combined_thresh_c], lrange)
-        ) / numpy.array(tot_fi_thr_c)
-        C2 = numpy.array(
-            scipy.ndimage.sum(si_thresh_c, labels[combined_thresh_c], lrange)
-        ) / numpy.array(tot_si_thr_c)
-
+def get_correlation_overlap_ind(
+    pixels_1: NDArray[numpy.floating],
+    pixels_2: NDArray[numpy.floating],
+    mask: NDArray[numpy.integer],
+    thr: int = 15,
+) -> dict[str, float]:
+    fi = pixels_1[mask]
+    si = pixels_2[mask]
+    overlap, K1, K2 = _overlap_pair(fi, si, thr)
     return {
-        f"{F_COSTES_FORMAT}_1": C1[0],
-        f"{F_COSTES_FORMAT}_2": C2[0],
+        F_OVERLAP_FORMAT: overlap,
+        f"{F_K_FORMAT}_1": K1,
+        f"{F_K_FORMAT}_2": K2,
     }
 
 
+# ---------------------------------------------------------------------------
+# Costes' automated threshold (unchanged algorithms; first_pixels/second_pixels
+# arguments are unused historically but kept for API compatibility).
+# ---------------------------------------------------------------------------
+
+
 def linear_costes(
-    first_pixels: NDArray[numpy.floating],
-    second_pixels: NDArray[numpy.floating],
+    first_pixels: NDArray[numpy.floating] | None,
+    second_pixels: NDArray[numpy.floating] | None,
     fi: NDArray[numpy.floating],
     si: NDArray[numpy.floating],
     scale_max: int = 255,
@@ -456,8 +447,8 @@ def linear_costes(
 
 
 def bisection_costes(
-    first_pixels: NDArray[numpy.floating],
-    second_pixels: NDArray[numpy.floating],
+    first_pixels: NDArray[numpy.floating] | None,
+    second_pixels: NDArray[numpy.floating] | None,
     fi: NDArray[numpy.floating],
     si: NDArray[numpy.floating],
     scale_max: int = 255,
@@ -529,70 +520,6 @@ def bisection_costes(
     return thr_fi_c, thr_si_c
 
 
-def get_correlation_overlap_ind(
-    pixels_1: NDArray[numpy.floating],
-    pixels_2: NDArray[numpy.floating],
-    mask: NDArray[numpy.integer],
-    thr: int = 15,
-) -> dict[str, float]:
-    first_pixels, second_pixels, labels, lrange = extract_pixels(
-        pixels_1, pixels_2, mask
-    )
-    _, _, _, _, combined_thresh = calculate_threshold(pixels_1, pixels_2, mask, thr)
-    # Overlap Coefficient
-    K1: float | numpy.ndarray = 0.0
-    K2: float | numpy.ndarray = 0.0
-    if combined_thresh.any():  # TODO adjust for multiple labels
-        fpsq = scipy.ndimage.sum(
-            first_pixels[combined_thresh] ** 2,
-            labels[combined_thresh],
-            lrange,
-        )
-        spsq = scipy.ndimage.sum(
-            second_pixels[combined_thresh] ** 2,
-            labels[combined_thresh],
-            lrange,
-        )
-        pdt = numpy.sqrt(numpy.array(fpsq) * numpy.array(spsq))
-
-        overlap = fix(
-            scipy.ndimage.sum(
-                first_pixels[combined_thresh] * second_pixels[combined_thresh],
-                labels[combined_thresh],
-                lrange,
-            )
-            / pdt
-        )
-        K1 = fix(
-            (
-                scipy.ndimage.sum(
-                    first_pixels[combined_thresh] * second_pixels[combined_thresh],
-                    labels[combined_thresh],
-                    lrange,
-                )
-            )
-            / (numpy.array(fpsq))
-        )
-        K2 = fix(
-            scipy.ndimage.sum(
-                first_pixels[combined_thresh] * second_pixels[combined_thresh],
-                labels[combined_thresh],
-                lrange,
-            )
-            / numpy.array(spsq)
-        )
-
-        # TODO Revert this block once integer labels are supported
-        K1 = K1[0]  # type: ignore[index]
-        K2 = K2[0]  # type: ignore[index]
-    is_scalar = numpy.isscalar(K1)
-    return {
-        F_OVERLAP_FORMAT: overlap[0],
-        f"{F_K_FORMAT}_1": K1 if is_scalar else K1[0],  # type: ignore[index, dict-item]
-        f"{F_K_FORMAT}_2": K2 if is_scalar else K2[0],  # type: ignore[index, dict-item]
-    }
-
-
 # MODIFIED: This reproduces the behaviour of the block at
 #  https://github.com/cellprofiler/CellProfiler/blob/450abdc2eaa0332cb6d1d4aaed4bf0a4b843368d/src/subpackages/core/cellprofiler_core/image/abstract_image/file/_file_image.py#L396-L405
 def infer_scale(data: numpy.ndarray) -> int:
@@ -610,14 +537,29 @@ def infer_scale(data: numpy.ndarray) -> int:
     return scale
 
 
-## Define functions using skimage style
-# The implementation of these correlation functions makes it irrelevant to vectorize the input.
+# ---------------------------------------------------------------------------
+# Public multi-label entry points. These iterate per label using find_objects
+# (bounding-box slicing) and use plain numpy reductions per label rather than
+# scipy.ndimage.sum / maximum across the full label image.
+# ---------------------------------------------------------------------------
+
+
 def get_correlation_pearson(
     pixels_1: NDArray[numpy.floating],
     pixels_2: NDArray[numpy.floating],
     masks: NDArray[numpy.integer],
 ) -> dict[str, list[float]]:
-    return apply_correlation_fun(get_correlation_pearson_ind, pixels_1, pixels_2, masks)
+    corrs: list[float] = []
+    slopes: list[float] = []
+    for fi, si in _iter_label_pixels(pixels_1, pixels_2, masks):
+        if fi is None or si is None or fi.size == 0:
+            corrs.append(0.0)
+            slopes.append(0.0)
+            continue
+        corr, slope = _pearson_pair(fi, si)
+        corrs.append(corr)
+        slopes.append(slope)
+    return {F_CORRELATION_FORMAT: corrs, F_SLOPE_FORMAT: slopes}
 
 
 def get_correlation_manders_fold(
@@ -626,9 +568,17 @@ def get_correlation_manders_fold(
     masks: NDArray[numpy.integer],
     thr: int = 15,
 ) -> dict[str, list[float]]:
-    return apply_correlation_fun(
-        get_correlation_manders_fold_ind, pixels_1, pixels_2, masks, thr=thr
-    )
+    m1_list: list[float] = []
+    m2_list: list[float] = []
+    for fi, si in _iter_label_pixels(pixels_1, pixels_2, masks):
+        if fi is None or si is None or fi.size == 0:
+            m1_list.append(0.0)
+            m2_list.append(0.0)
+            continue
+        M1, M2 = _manders_pair(fi, si, thr)
+        m1_list.append(M1)
+        m2_list.append(M2)
+    return {f"{F_MANDERS_FORMAT}_1": m1_list, f"{F_MANDERS_FORMAT}_2": m2_list}
 
 
 def get_correlation_rwc(
@@ -637,9 +587,17 @@ def get_correlation_rwc(
     masks: NDArray[numpy.integer],
     thr: int = 15,
 ) -> dict[str, list[float]]:
-    return apply_correlation_fun(
-        get_correlation_rwc_ind, pixels_1, pixels_2, masks, thr=thr
-    )
+    r1: list[float] = []
+    r2: list[float] = []
+    for fi, si in _iter_label_pixels(pixels_1, pixels_2, masks):
+        if fi is None or si is None or fi.size == 0:
+            r1.append(0.0)
+            r2.append(0.0)
+            continue
+        RWC1, RWC2 = _rwc_pair(fi, si, thr)
+        r1.append(RWC1)
+        r2.append(RWC2)
+    return {f"{F_RWC_FORMAT}_1": r1, f"{F_RWC_FORMAT}_2": r2}
 
 
 def get_correlation_costes(
@@ -649,14 +607,18 @@ def get_correlation_costes(
     fast_costes: str = M_FASTER,
     thr: int = 15,
 ) -> dict[str, list[float]]:
-    return apply_correlation_fun(
-        get_correlation_costes_ind,
-        pixels_1,
-        pixels_2,
-        masks,
-        fast_costes=fast_costes,
-        thr=thr,
-    )
+    scale = infer_scale(pixels_1)
+    c1: list[float] = []
+    c2: list[float] = []
+    for fi, si in _iter_label_pixels(pixels_1, pixels_2, masks):
+        if fi is None or si is None or fi.size == 0:
+            c1.append(0.0)
+            c2.append(0.0)
+            continue
+        C1, C2 = _costes_pair(fi, si, scale, fast_costes)
+        c1.append(C1)
+        c2.append(C2)
+    return {f"{F_COSTES_FORMAT}_1": c1, f"{F_COSTES_FORMAT}_2": c2}
 
 
 def get_correlation_overlap(
@@ -665,26 +627,21 @@ def get_correlation_overlap(
     masks: NDArray[numpy.integer],
     thr: int = 15,
 ) -> dict[str, list[float]]:
-    return apply_correlation_fun(get_correlation_overlap_ind, pixels_1, pixels_2, masks)
-
-
-# Helper functions
-
-
-def apply_correlation_fun(
-    corr_function: Callable[..., dict[str, float]],
-    pixels_1: NDArray[numpy.floating],
-    pixels_2: NDArray[numpy.floating],
-    masks: NDArray[numpy.integer],
-    **kwargs,
-) -> dict[str, list[float]]:
-    """
-    Apply `corr_function` to the subsequent args and kwargs. It assumes that pixels (arrays containing images) are passed, as well as
-    masks in a 2-d labels format. Any kwargs are passed to corr_functions.
-    """
-    results = []
-    partial_corr_fun = partial(corr_function, pixels_1, pixels_2)
-    for mask in labels_to_binmasks(masks):
-        results.append(partial_corr_fun(mask, **kwargs))
-
-    return {k: [item[k] for item in results] for k in results[0]}
+    overlap_list: list[float] = []
+    k1_list: list[float] = []
+    k2_list: list[float] = []
+    for fi, si in _iter_label_pixels(pixels_1, pixels_2, masks):
+        if fi is None or si is None or fi.size == 0:
+            overlap_list.append(0.0)
+            k1_list.append(0.0)
+            k2_list.append(0.0)
+            continue
+        overlap, K1, K2 = _overlap_pair(fi, si, thr)
+        overlap_list.append(overlap)
+        k1_list.append(K1)
+        k2_list.append(K2)
+    return {
+        F_OVERLAP_FORMAT: overlap_list,
+        f"{F_K_FORMAT}_1": k1_list,
+        f"{F_K_FORMAT}_2": k2_list,
+    }

--- a/src/cp_measure/core/measureobjectintensity.py
+++ b/src/cp_measure/core/measureobjectintensity.py
@@ -1,7 +1,6 @@
 import numpy
 import scipy.ndimage
 import skimage.segmentation
-from cp_measure.utils import _ensure_np_array as fix
 from numpy.typing import NDArray
 
 __doc__ = """
@@ -124,259 +123,144 @@ def get_intensity(
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
 ) -> dict[str, NDArray[numpy.floating]]:
-    """
-    masks is a labeled array where 0 are background images.
-    """
-    masked_image = pixels
+    """Per-object intensity features.
 
+    Walks each object on its `scipy.ndimage.find_objects` bounding box
+    rather than the full image, and uses batched `scipy.ndimage` calls
+    for whole-image stats (max position, intensity-weighted and geometric
+    centers of mass). 2D inputs are promoted to ``(1, Y, X)`` so the same
+    code path handles 2D and 3D; for 3D inputs Z-axis locations are filled
+    in `CenterMassIntensity_Z` / `MaxIntensity_Z`.
+    """
+    # Normalize to (Z, Y, X). Broadcast 2D masks across a 3D pixel stack
+    # to match the original behavior.
+    if pixels.ndim == 3 and masks.ndim == 2:
+        masks = numpy.broadcast_to(masks, pixels.shape)
     if pixels.ndim == 2:
-        img = pixels.reshape(1, *pixels.shape)
-        masked_image = img
-    elif pixels.ndim == 3 and masks.ndim == 2:  # 3D image, 2D mask.
-        masks = masks.reshape(1, *masks.shape)
+        pixels = pixels[numpy.newaxis, ...]
+    if masks.ndim == 2:
+        masks = masks[numpy.newaxis, ...]
 
-    unique_vals = numpy.unique(masks)
-    # MODIFIED: Extract the number of objects by explicitly removing 0s
-    nobjects = (unique_vals > 0).sum()
+    if not numpy.issubdtype(masks.dtype, numpy.integer):
+        masks = masks.astype(numpy.intp, copy=False)
 
-    integrated_intensity = numpy.zeros((nobjects,))
-    mean_intensity = numpy.zeros((nobjects,))
-    std_intensity = numpy.zeros((nobjects,))
-    min_intensity = numpy.zeros((nobjects,))
-    max_intensity = numpy.zeros((nobjects,))
-    mass_displacement = numpy.zeros((nobjects,))
-    lower_quartile_intensity = numpy.zeros((nobjects,))
-    median_intensity = numpy.zeros((nobjects,))
-    mad_intensity = numpy.zeros((nobjects,))
-    upper_quartile_intensity = numpy.zeros((nobjects,))
-    cmi_x = numpy.zeros((nobjects,))
-    cmi_y = numpy.zeros((nobjects,))
-    cmi_z = numpy.zeros((nobjects,))
-    max_x = numpy.zeros((nobjects,))
-    max_y = numpy.zeros((nobjects,))
-    max_z = numpy.zeros((nobjects,))
+    # find_objects returns one slice per label in 1..max(masks), with None
+    # for missing labels. We use it both for bbox crops below and to derive
+    # the present-label list — np.unique on a multi-MB mask is much slower
+    # (e.g. ~200 ms on a 32x240x240 volume).
+    bboxes = scipy.ndimage.find_objects(masks)
+    present = [(i + 1, sl) for i, sl in enumerate(bboxes) if sl is not None]
+    nobjects = len(present)
 
-    label_matrices = numpy.zeros((nobjects, *masks.shape), dtype=int)  # N,Y,X
-    unique_labels = unique_vals[unique_vals > 0]
-    for i, label in enumerate(
-        unique_labels
-    ):  # Assumes all labels from 1 to nobjects are present
-        label_matrices[i][masks == label] = label
+    integrated_intensity = numpy.zeros(nobjects)
+    mean_intensity = numpy.zeros(nobjects)
+    std_intensity = numpy.zeros(nobjects)
+    min_intensity = numpy.zeros(nobjects)
+    max_intensity = numpy.zeros(nobjects)
+    lower_quartile_intensity = numpy.zeros(nobjects)
+    median_intensity = numpy.zeros(nobjects)
+    mad_intensity = numpy.zeros(nobjects)
+    upper_quartile_intensity = numpy.zeros(nobjects)
+
+    cmi_z = numpy.zeros(nobjects)
+    cmi_y = numpy.zeros(nobjects)
+    cmi_x = numpy.zeros(nobjects)
+    max_z = numpy.zeros(nobjects)
+    max_y = numpy.zeros(nobjects)
+    max_x = numpy.zeros(nobjects)
+    mass_displacement = numpy.zeros(nobjects)
+
+    for out_i, (label_value, sl) in enumerate(present):
+        mask_crop = masks[sl] == label_value
+        pixels_crop = pixels[sl]
+        finite = mask_crop & numpy.isfinite(pixels_crop)
+        if not finite.any():
+            continue
+        vals = pixels_crop[finite]
+
+        integrated = vals.sum()
+        integrated_intensity[out_i] = integrated
+        mean_intensity[out_i] = vals.mean()
+        std_intensity[out_i] = vals.std()
+
+        q = numpy.percentile(vals, [0, 25, 50, 75, 100])
+        min_intensity[out_i] = q[0]
+        lower_quartile_intensity[out_i] = q[1]
+        median_intensity[out_i] = q[2]
+        upper_quartile_intensity[out_i] = q[3]
+        max_intensity[out_i] = q[4]
+        mad_intensity[out_i] = numpy.median(numpy.abs(vals - q[2]))
+
+        # Positions / centroids on the bbox crop, then shift by the bbox
+        # offset. This avoids any full-image scipy.ndimage scans.
+        coords = numpy.argwhere(finite)
+        offset = numpy.array([s.start for s in sl], dtype=coords.dtype)
+        coords = coords + offset
+
+        argmax = int(numpy.argmax(vals))
+        max_z[out_i] = coords[argmax, 0]
+        max_y[out_i] = coords[argmax, 1]
+        max_x[out_i] = coords[argmax, 2]
+
+        cm = coords.mean(axis=0)
+        if integrated != 0:
+            cmi = (coords * vals[:, numpy.newaxis]).sum(axis=0) / integrated
+        else:
+            cmi = numpy.full(coords.shape[1], numpy.nan)
+        cmi_z[out_i] = cmi[0]
+        cmi_y[out_i] = cmi[1]
+        cmi_x[out_i] = cmi[2]
+
+        diff = cmi - cm
+        mass_displacement[out_i] = numpy.sqrt((diff * diff).sum())
+
+    result: dict[str, NDArray[numpy.floating]] = {
+        f"{INTENSITY}_{INTEGRATED_INTENSITY}": integrated_intensity,
+        f"{INTENSITY}_{MEAN_INTENSITY}": mean_intensity,
+        f"{INTENSITY}_{STD_INTENSITY}": std_intensity,
+        f"{INTENSITY}_{MIN_INTENSITY}": min_intensity,
+        f"{INTENSITY}_{MAX_INTENSITY}": max_intensity,
+        f"{INTENSITY}_{MASS_DISPLACEMENT}": mass_displacement,
+        f"{INTENSITY}_{LOWER_QUARTILE_INTENSITY}": lower_quartile_intensity,
+        f"{INTENSITY}_{MEDIAN_INTENSITY}": median_intensity,
+        f"{INTENSITY}_{MAD_INTENSITY}": mad_intensity,
+        f"{INTENSITY}_{UPPER_QUARTILE_INTENSITY}": upper_quartile_intensity,
+        f"{C_LOCATION}_{LOC_CMI_X}": cmi_x,
+        f"{C_LOCATION}_{LOC_CMI_Y}": cmi_y,
+        f"{C_LOCATION}_{LOC_CMI_Z}": cmi_z,
+        f"{C_LOCATION}_{LOC_MAX_X}": max_x,
+        f"{C_LOCATION}_{LOC_MAX_Y}": max_y,
+        f"{C_LOCATION}_{LOC_MAX_Z}": max_z,
+    }
 
     if edge_measurements:
-        integrated_intensity_edge = numpy.zeros((nobjects,))
-        mean_intensity_edge = numpy.zeros((nobjects,))
-        std_intensity_edge = numpy.zeros((nobjects,))
-        min_intensity_edge = numpy.zeros((nobjects,))
-        max_intensity_edge = numpy.zeros((nobjects,))
+        integrated_intensity_edge = numpy.zeros(nobjects)
+        mean_intensity_edge = numpy.zeros(nobjects)
+        std_intensity_edge = numpy.zeros(nobjects)
+        min_intensity_edge = numpy.zeros(nobjects)
+        max_intensity_edge = numpy.zeros(nobjects)
 
-    result = {}
-    # for labels, lindexes in ((mask, numpy.array([1])),):
-    for labels, lindexes in zip(label_matrices, unique_labels):
-        lindexes = lindexes[lindexes != 0]
+        # One pass to compute the inner boundary of every object, then
+        # index into the bbox crop per label.
+        boundaries = skimage.segmentation.find_boundaries(masks, mode="inner")
 
-        if pixels.ndim == 2:
-            labels = labels.reshape(1, *labels.shape)
+        for out_i, (label_value, sl) in enumerate(present):
+            mask_crop = masks[sl] == label_value
+            pixels_crop = pixels[sl]
+            edge = mask_crop & boundaries[sl] & numpy.isfinite(pixels_crop)
+            if not edge.any():
+                continue
+            evals = pixels_crop[edge]
+            integrated_intensity_edge[out_i] = evals.sum()
+            mean_intensity_edge[out_i] = evals.mean()
+            std_intensity_edge[out_i] = evals.std()
+            min_intensity_edge[out_i] = evals.min()
+            max_intensity_edge[out_i] = evals.max()
 
-        masked_labels = labels
-
-        lmask = (masked_labels > 0) & numpy.isfinite(masked_image)  # Ignore NaNs, Infs
-        has_objects = numpy.any(lmask)
-        if has_objects:
-            limg = masked_image[lmask]
-
-            llabels = labels[lmask]
-
-            mesh_z, mesh_y, mesh_x = numpy.mgrid[
-                0 : masked_image.shape[0],
-                0 : masked_image.shape[1],
-                0 : masked_image.shape[2],
-            ]
-
-            mesh_x = mesh_x[lmask]
-            mesh_y = mesh_y[lmask]
-            mesh_z = mesh_z[lmask]
-
-            lcount = fix(scipy.ndimage.sum(numpy.ones(len(limg)), llabels, lindexes))
-
-            integrated_intensity[lindexes - 1] = fix(
-                scipy.ndimage.sum(limg, llabels, lindexes)
-            )
-
-            mean_intensity[lindexes - 1] = integrated_intensity[lindexes - 1] / lcount
-
-            std_intensity[lindexes - 1] = numpy.sqrt(
-                fix(
-                    scipy.ndimage.mean(
-                        (limg - mean_intensity[llabels - 1]) ** 2,
-                        llabels,
-                        lindexes,
-                    )
-                )
-            )
-
-            min_intensity[lindexes - 1] = fix(
-                scipy.ndimage.minimum(limg, llabels, lindexes)
-            )
-
-            max_intensity[lindexes - 1] = fix(
-                scipy.ndimage.maximum(limg, llabels, lindexes)
-            )
-
-            # Compute the position of the intensity maximum
-            max_position = numpy.array(
-                fix(scipy.ndimage.maximum_position(limg, llabels, lindexes)),
-                dtype=int,
-            )
-            max_position = numpy.reshape(max_position, (max_position.shape[0],))
-
-            max_x[lindexes - 1] = mesh_x[max_position]
-            max_y[lindexes - 1] = mesh_y[max_position]
-            max_z[lindexes - 1] = mesh_z[max_position]
-
-            # The mass displacement is the distance between the center
-            # of mass of the binary image and of the intensity image. The
-            # center of mass is the average X or Y for the binary image
-            # and the sum of X or Y * intensity / integrated intensity
-            cm_x = fix(scipy.ndimage.mean(mesh_x, llabels, lindexes))
-            cm_y = fix(scipy.ndimage.mean(mesh_y, llabels, lindexes))
-            cm_z = fix(scipy.ndimage.mean(mesh_z, llabels, lindexes))
-
-            i_x = fix(scipy.ndimage.sum(mesh_x * limg, llabels, lindexes))
-            i_y = fix(scipy.ndimage.sum(mesh_y * limg, llabels, lindexes))
-            i_z = fix(scipy.ndimage.sum(mesh_z * limg, llabels, lindexes))
-
-            cmi_x[lindexes - 1] = i_x / integrated_intensity[lindexes - 1]
-            cmi_y[lindexes - 1] = i_y / integrated_intensity[lindexes - 1]
-            cmi_z[lindexes - 1] = i_z / integrated_intensity[lindexes - 1]
-
-            diff_x = cm_x - cmi_x[lindexes - 1]
-            diff_y = cm_y - cmi_y[lindexes - 1]
-            diff_z = cm_z - cmi_z[lindexes - 1]
-
-            mass_displacement[lindexes - 1] = numpy.sqrt(
-                diff_x * diff_x + diff_y * diff_y + diff_z * diff_z
-            )
-
-            #
-            # Sort the intensities by label, then intensity.
-            # For each label, find the index above and below
-            # the 25%, 50% and 75% mark and take the weighted
-            # average.
-            #
-            order = numpy.lexsort((limg, llabels))
-            areas = lcount.astype(int)
-            indices = numpy.cumsum(areas) - areas
-            for dest, fraction in (
-                (lower_quartile_intensity, 1.0 / 4.0),
-                (median_intensity, 1.0 / 2.0),
-                (upper_quartile_intensity, 3.0 / 4.0),
-            ):
-                qindex = indices.astype(float) + areas * fraction
-                qfraction = qindex - numpy.floor(qindex)
-                qindex = qindex.astype(int)
-                qmask = qindex < indices + areas - 1
-                qi = qindex[qmask]
-                qf = qfraction[qmask]
-                dest[lindexes[qmask] - 1] = (
-                    limg[order[qi]] * (1 - qf) + limg[order[qi + 1]] * qf
-                )
-
-                #
-                # In some situations (e.g., only 3 points), there may
-                # not be an upper bound.
-                #
-                qmask = (~qmask) & (areas > 0)
-                dest[lindexes[qmask] - 1] = limg[order[qindex[qmask]]]
-
-            #
-            # Once again, for the MAD
-            #
-            madimg = numpy.abs(limg - median_intensity[llabels - 1])
-            order = numpy.lexsort((madimg, llabels))
-            qindex = indices.astype(float) + areas / pixels.ndim
-            qfraction = qindex - numpy.floor(qindex)
-            qindex = qindex.astype(int)
-            qmask = qindex < indices + areas - 1
-            qi = qindex[qmask]
-            qf = qfraction[qmask]
-            mad_intensity[lindexes[qmask] - 1] = (
-                madimg[order[qi]] * (1 - qf) + madimg[order[qi + 1]] * qf
-            )
-            qmask = (~qmask) & (areas > 0)
-            mad_intensity[lindexes[qmask] - 1] = madimg[order[qindex[qmask]]]
-
-            # END OF ITERATIONS
-
-        if edge_measurements:
-            outlines = skimage.segmentation.find_boundaries(labels, mode="inner")
-            masked_outlines = outlines
-            emask = masked_outlines > 0
-            eimg = masked_image[emask]
-            elabels = labels[emask]
-            has_edge = len(eimg) > 0
-
-            if has_edge:
-                ecount = fix(
-                    scipy.ndimage.sum(numpy.ones(len(eimg)), elabels, lindexes)
-                )
-
-                integrated_intensity_edge[lindexes - 1] = fix(
-                    scipy.ndimage.sum(eimg, elabels, lindexes)
-                )
-
-                mean_intensity_edge[lindexes - 1] = (
-                    integrated_intensity_edge[lindexes - 1] / ecount
-                )
-
-                std_intensity_edge[lindexes - 1] = numpy.sqrt(
-                    fix(
-                        scipy.ndimage.mean(
-                            (eimg - mean_intensity_edge[elabels - 1]) ** 2,
-                            elabels,
-                        )
-                    )
-                )
-
-                min_intensity_edge[lindexes - 1] = fix(
-                    scipy.ndimage.minimum(eimg, elabels, lindexes)
-                )
-
-                max_intensity_edge[lindexes - 1] = fix(
-                    scipy.ndimage.maximum(eimg, elabels, lindexes)
-                )
-
-    measurement_names = [
-        (INTENSITY, INTEGRATED_INTENSITY, integrated_intensity),
-        (INTENSITY, MEAN_INTENSITY, mean_intensity),
-        (INTENSITY, STD_INTENSITY, std_intensity),
-        (INTENSITY, MIN_INTENSITY, min_intensity),
-        (INTENSITY, MAX_INTENSITY, max_intensity),
-        (INTENSITY, MASS_DISPLACEMENT, mass_displacement),
-        (INTENSITY, LOWER_QUARTILE_INTENSITY, lower_quartile_intensity),
-        (INTENSITY, MEDIAN_INTENSITY, median_intensity),
-        (INTENSITY, MAD_INTENSITY, mad_intensity),
-        (INTENSITY, UPPER_QUARTILE_INTENSITY, upper_quartile_intensity),
-        (C_LOCATION, LOC_CMI_X, cmi_x),
-        (C_LOCATION, LOC_CMI_Y, cmi_y),
-        (C_LOCATION, LOC_CMI_Z, cmi_z),
-        (C_LOCATION, LOC_MAX_X, max_x),
-        (C_LOCATION, LOC_MAX_Y, max_y),
-        (C_LOCATION, LOC_MAX_Z, max_z),
-    ]
-    if edge_measurements:
-        measurement_names.extend(
-            [
-                (INTENSITY, INTEGRATED_INTENSITY_EDGE, integrated_intensity_edge),
-                (INTENSITY, MEAN_INTENSITY_EDGE, mean_intensity_edge),
-                (INTENSITY, STD_INTENSITY_EDGE, std_intensity_edge),
-                (INTENSITY, MIN_INTENSITY_EDGE, min_intensity_edge),
-                (INTENSITY, MAX_INTENSITY_EDGE, max_intensity_edge),
-            ]
-        )
-    for category, feature_name, measurement in measurement_names:
-        measurement_name = "{}_{}".format(category, feature_name)
-        # MODIFIED: Selected first
-        result[measurement_name] = measurement
+        result[f"{INTENSITY}_{INTEGRATED_INTENSITY_EDGE}"] = integrated_intensity_edge
+        result[f"{INTENSITY}_{MEAN_INTENSITY_EDGE}"] = mean_intensity_edge
+        result[f"{INTENSITY}_{STD_INTENSITY_EDGE}"] = std_intensity_edge
+        result[f"{INTENSITY}_{MIN_INTENSITY_EDGE}"] = min_intensity_edge
+        result[f"{INTENSITY}_{MAX_INTENSITY_EDGE}"] = max_intensity_edge
 
     return result

--- a/src/cp_measure/core/measureobjectintensity.py
+++ b/src/cp_measure/core/measureobjectintensity.py
@@ -122,6 +122,7 @@ def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
+    legacy_mad: bool = False,
 ) -> dict[str, NDArray[numpy.floating]]:
     """Per-object intensity features.
 
@@ -131,7 +132,20 @@ def get_intensity(
     centers of mass). 2D inputs are promoted to ``(1, Y, X)`` so the same
     code path handles 2D and 3D; for 3D inputs Z-axis locations are filled
     in `CenterMassIntensity_Z` / `MaxIntensity_Z`.
+
+    Parameters
+    ----------
+    legacy_mad
+        When False (default) MAD is the textbook ``median(|x - median(x)|)``.
+        When True, reproduce the original cp_measure / CellProfiler behavior,
+        which used the ``(100 / pixels.ndim) %`` quantile of ``|x - median(x)|``
+        in place of the median — equivalent in 2D but returns the 33rd
+        percentile in 3D rather than the median.
     """
+    # Captured before the reshape below so legacy MAD matches the original
+    # code, which read pixels.ndim from the un-normalized input.
+    source_ndim = pixels.ndim
+
     # Normalize to (Z, Y, X). Broadcast 2D masks across a 3D pixel stack
     # to match the original behavior.
     if pixels.ndim == 3 and masks.ndim == 2:
@@ -189,7 +203,12 @@ def get_intensity(
         median_intensity[out_i] = q[2]
         upper_quartile_intensity[out_i] = q[3]
         max_intensity[out_i] = q[4]
-        mad_intensity[out_i] = numpy.median(numpy.abs(vals - q[2]))
+        if legacy_mad:
+            mad_intensity[out_i] = numpy.percentile(
+                numpy.abs(vals - q[2]), 100.0 / source_ndim
+            )
+        else:
+            mad_intensity[out_i] = numpy.median(numpy.abs(vals - q[2]))
 
         # Positions / centroids on the bbox crop, then shift by the bbox
         # offset. This avoids any full-image scipy.ndimage scans.

--- a/src/cp_measure/core/measureobjectsizeshape.py
+++ b/src/cp_measure/core/measureobjectsizeshape.py
@@ -7,7 +7,7 @@ import centrosome.zernike
 import numpy
 import scipy.ndimage
 import skimage.measure
-from cp_measure.utils import masks_to_ijv, _ensure_np_scalar
+from cp_measure.utils import masks_to_ijv
 
 __doc__ = """\
 MeasureObjectSizeShape
@@ -644,21 +644,14 @@ def get_sizeshape(
         median_radius = numpy.zeros(nobjects)
         mean_radius = numpy.zeros(nobjects)
         for index, mini_image in enumerate(props["image"]):
-            # Pad image to assist distance tranform
+            # Pad image to assist distance transform
             mini_image = numpy.pad(mini_image, 1)
             distances = scipy.ndimage.distance_transform_edt(mini_image)
 
-            max_radius[index] = _ensure_np_scalar(
-                scipy.ndimage.maximum(distances, mini_image)
-            )
-            mean_radius[index] = _ensure_np_scalar(
-                scipy.ndimage.mean(distances, mini_image)
-            )
-            median_radius[index] = _ensure_np_scalar(
-                centrosome.cpmorphology.median_of_labels(
-                    distances, mini_image.astype("int"), [1]
-                )
-            )
+            inside = distances[mini_image]
+            max_radius[index] = inside.max()
+            mean_radius[index] = inside.mean()
+            median_radius[index] = numpy.median(inside)
 
         results |= {
             F_AREA: props["area"],

--- a/src/cp_measure/core/numba/measureobjectintensity.py
+++ b/src/cp_measure/core/numba/measureobjectintensity.py
@@ -54,6 +54,7 @@ def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
+    legacy_mad: bool = False,
 ) -> dict[str, NDArray[numpy.floating]]:
     """masks is a labeled array where 0 are background."""
     orig_ndim = pixels.ndim
@@ -127,12 +128,13 @@ def get_intensity(
                 (cm_x - cmi_x) ** 2 + (cm_y - cmi_y) ** 2 + (cm_z - cmi_z) ** 2
             )
 
+        mad_frac = 1.0 / orig_ndim if legacy_mad else 0.5
         (
             lower_quartile_intensity,
             median_intensity,
             upper_quartile_intensity,
             mad_intensity,
-        ) = segment_quantiles(values, seg0, count, nobjects, 1.0 / orig_ndim)
+        ) = segment_quantiles(values, seg0, count, nobjects, mad_frac)
 
     if edge_measurements:
         integrated_intensity_edge = numpy.zeros(nobjects)

--- a/src/cp_measure/utils.py
+++ b/src/cp_measure/utils.py
@@ -31,22 +31,13 @@ def get_test_pixels_mask():
 
 def masks_to_ijv(masks: numpy.ndarray) -> numpy.ndarray:
     """
-    input: 2d boolean array
-    output: (n, 3) integer array following (i,j,1)
+    input: 2d integer label array
+    output: (n, 3) integer array of rows (i, j, label) sorted by label
     """
-
-    # Extract coordinates of object from boolean mask
-    masks_ijv = numpy.empty((0, 3), dtype=int)
-    for label in range(masks.max()):
-        i, j = numpy.where(masks == label + 1)
-        n = len(i)
-        ijv = numpy.empty((n, 3), dtype=int)
-        ijv[:, 0] = i
-        ijv[:, 1] = j
-        ijv[:, 2] = label + 1
-        masks_ijv = numpy.concatenate((masks_ijv, ijv))
-
-    return masks_ijv
+    i, j = numpy.nonzero(masks)
+    v = masks[i, j]
+    order = numpy.argsort(v, kind="stable")
+    return numpy.column_stack((i[order], j[order], v[order])).astype(int, copy=False)
 
 
 def labels_to_binmasks(masks: numpy.ndarray) -> numpy.ndarray:


### PR DESCRIPTION
Complementary to the jax/numba improvements, I'm finally also modifying the original implementations. Numpy-only speed improvements (no additional deps)

intensity
```
  ┌──────────────────────────────────┬─────────┬────────┬─────────┐                                                                                                                   
  │              Scene               │   Old   │  New   │ Speedup │
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, 200 small objects (512²)     │ 4225 ms │ 57 ms  │ 74.0x   │
  ├──────────────────────────────────┼─────────┼────────┼─────────┤
  │ 3D, 2 cubes (32×240×240, 2 obj)  │ 2089 ms │ 196 ms │ 10.7x   │                                                                                                                   
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, 2-pixel object               │ 33 ms   │ 5.7 ms │ 5.7x    │                                                                                                                   
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, full_2 (2 large objects)     │ 43 ms   │ 8.4 ms │ 5.1x    │
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, 1-pixel object               │ 30 ms   │ 7.6 ms │ 3.9x    │                                                                                 
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, center                       │ 154 ms  │ 45 ms  │ 3.4x    │                                                                                 
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, edges                        │ 47 ms   │ 14 ms  │ 3.3x    │
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, benchmark_core (500², 2 obj) │ 136 ms  │ 43 ms  │ 3.2x    │
  ├──────────────────────────────────┼─────────┼────────┼─────────┤                                                                                                                   
  │ 2D, full (1 huge object)         │ 44 ms   │ 25 ms  │ 1.8x    │                                                                                 
  └──────────────────────────────────┴─────────┴────────┴─────────┘                                                                                                                   
```
sizeshape/feret
```
  ┌───────────────┬───────────┬───────────────┬──────────────┐
  │ Size / labels │ get_feret │ get_sizeshape │ get_zernike* │
  ├───────────────┼───────────┼───────────────┼──────────────┤
  │ 256² / 16     │ 0.98x     │ 0.99x         │ —            │
  ├───────────────┼───────────┼───────────────┼──────────────┤
  │ 512² / 64     │ 1.88x     │ 1.19x         │ —            │
  ├───────────────┼───────────┼───────────────┼──────────────┤
  │ 1024² / 128   │ 2.95x     │ 1.11x         │ —            │
  └───────────────┴───────────┴───────────────┴──────────────┘
```

coloc
```
  ┌──────────────┬────────┬────────┬─────────┐                                                                                                                                        
  │   Function   │  Old   │  New   │ Speedup │                                                                                                                                        
  ├──────────────┼────────┼────────┼─────────┤                        
  │ pearson      │ 202 ms │ 35 ms  │ 5.8×    │
  ├──────────────┼────────┼────────┼─────────┤
  │ manders_fold │ 334 ms │ 14 ms  │ 23×     │                                                                                                                                        
  ├──────────────┼────────┼────────┼─────────┤
  │ rwc          │ 546 ms │ 124 ms │ 4.4×    │                                                                                                                                        
  ├──────────────┼────────┼────────┼─────────┤                                                                                                                                        
  │ overlap      │ 451 ms │ 17 ms  │ 27×     │
  ├──────────────┼────────┼────────┼─────────┤                                                                                                                                        
  │ costes       │ 412 ms │ 54 ms  │ 7.7×    │                        
  └──────────────┴────────┴────────┴─────────┘
```