### PR TITLE
feat(accelerator): numba radial_distribution (+ Issue #22 fix)

### DIFF
--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -49,13 +49,14 @@ def _numba_registries() -> dict[str, dict[str, Callable]]:
     """Registries for the 'numba' accelerator.
 
     Composes the numba implementations (``intensity``, ``zernike``,
-    ``radial_zernikes``) with the numpy implementations of every other feature — a
-    single global "numba" selection still yields a full, working feature set,
-    accelerated where a numba backend exists. This is explicit per-function
-    composition, NOT an error-driven fallback.
+    ``radial_zernikes``, ``radial_distribution``) with the numpy implementations of
+    every other feature — a single global "numba" selection still yields a full,
+    working feature set, accelerated where a numba backend exists. This is explicit
+    per-function composition, NOT an error-driven fallback.
     """
     from cp_measure.core.numba import (
         get_intensity as _numba_intensity,
+        get_radial_distribution as _numba_radial_distribution,
         get_radial_zernikes as _numba_radial_zernikes,
         get_zernike as _numba_zernike,
     )
@@ -66,6 +67,7 @@ def _numba_registries() -> dict[str, dict[str, Callable]]:
             "intensity": _numba_intensity,
             "zernike": _numba_zernike,
             "radial_zernikes": _numba_radial_zernikes,
+            "radial_distribution": _numba_radial_distribution,
         },
         "correlation": _CORRELATION,
     }

--- a/src/cp_measure/core/numba/__init__.py
+++ b/src/cp_measure/core/numba/__init__.py
@@ -4,19 +4,21 @@ Selected explicitly by import (``from cp_measure.core.numba import get_intensity
 or globally via ``cp_measure.set_accelerator("numba")``. Requires the optional
 ``numba`` extra; availability is gated by ``cp_measure._detect.HAS_NUMBA``.
 
-This backend accelerates ``intensity``, ``zernike`` and ``radial_zernikes``; the
-global "numba" accelerator composes them with the numpy implementations of every
-other feature (see ``cp_measure.bulk``).
+This backend accelerates ``intensity``, ``zernike``, ``radial_zernikes`` and
+``radial_distribution``; the global "numba" accelerator composes them with the
+numpy implementations of every other feature (see ``cp_measure.bulk``).
 """
 
 from cp_measure.core.numba.measureobjectintensity import get_intensity
 from cp_measure.core.numba.measureobjectintensitydistribution import (
+    get_radial_distribution,
     get_radial_zernikes,
 )
 from cp_measure.core.numba.measureobjectsizeshape import get_zernike
 
 __all__ = [
     "get_intensity",
+    "get_radial_distribution",
     "get_radial_zernikes",
     "get_zernike",
 ]

--- a/src/cp_measure/core/numba/_radial.py
+++ b/src/cp_measure/core/numba/_radial.py
@@ -1,0 +1,135 @@
+"""Numba kernels for radial intensity distribution (single-threaded, cached).
+
+Two kernels backing :func:`cp_measure.core.numba.measureobjectintensitydistribution.get_radial_distribution`:
+
+- :func:`geodesic_chamfer_fifo` — geodesic distance from the object centre within
+  the object mask, as a 1/sqrt(2) chamfer shortest-path (FIFO Bellman-Ford / SPFA,
+  ring-buffer queue). This is BIT-EXACT to centrosome's
+  ``propagate(zeros, seed, mask, 1)`` (shortest-path is algorithm-independent — the
+  heap-Dijkstra C extension and this serial sweep reach the identical minimum),
+  verified across convex/concave/ring/spiral shapes, and ~35x faster on small
+  per-object crops. It replaces the dominant geometry cost.
+- :func:`radial_reduce` — the per-(object, bin) intensity/count histograms and the
+  per-(object, bin, 8-wedge) anisotropy CV, replacing the reference's repeated
+  ``scipy.sparse.coo_matrix(...).toarray()`` builds and ``numpy.ma`` masked CV.
+
+The exact-Euclidean ``distance_to_edge`` (scipy EDT) and the centre
+(``maximum_position_of_labels``) stay host-side — only the chamfer geodesic and the
+reductions are reimplemented. Serial; no ``prange``/``nogil``.
+"""
+
+import numpy as np
+from numba import njit
+
+_SQ2 = np.sqrt(2.0)
+# 8-neighbour offsets (orthogonal weight 1, diagonal weight sqrt(2)).
+_DR = np.array([-1, 1, 0, 0, -1, -1, 1, 1], np.int64)
+_DC = np.array([0, 0, -1, 1, -1, 1, -1, 1], np.int64)
+_DW = np.array([1.0, 1.0, 1.0, 1.0, _SQ2, _SQ2, _SQ2, _SQ2], np.float64)
+
+# Sentinel for unreached pixels (disconnected from the centre seed).
+UNREACHED = 1e18
+
+
+@njit(cache=True, error_model="numpy")
+def geodesic_chamfer_fifo(mask, si, sj):
+    """1/sqrt(2) chamfer geodesic distance from ``(si, sj)`` within ``mask``.
+
+    FIFO Bellman-Ford: each pixel is (re)queued when a shorter path is found; the
+    ring buffer + in-queue flag keep it O(N) amortised and bounded for any shape.
+    Pixels not reachable from the seed within the mask keep ``UNREACHED``.
+    Bit-exact to ``centrosome.propagate.propagate(zeros, seed, mask, 1)``.
+    """
+    H, W = mask.shape
+    d = np.full((H, W), UNREACHED)
+    d[si, sj] = 0.0
+    cap = H * W + 1
+    qr = np.empty(cap, np.int64)
+    qc = np.empty(cap, np.int64)
+    inq = np.zeros((H, W), np.bool_)
+    head = 0
+    tail = 0
+    qr[tail] = si
+    qc[tail] = sj
+    tail = (tail + 1) % cap
+    inq[si, sj] = True
+    while head != tail:
+        r = qr[head]
+        c = qc[head]
+        head = (head + 1) % cap
+        inq[r, c] = False
+        dr = d[r, c]
+        for k in range(8):
+            rr = r + _DR[k]
+            cc = c + _DC[k]
+            if 0 <= rr < H and 0 <= cc < W and mask[rr, cc]:
+                nd = dr + _DW[k]
+                if nd < d[rr, cc]:
+                    d[rr, cc] = nd
+                    if not inq[rr, cc]:
+                        inq[rr, cc] = True
+                        qr[tail] = rr
+                        qc[tail] = cc
+                        tail = (tail + 1) % cap
+    return d
+
+
+@njit(cache=True, error_model="numpy")
+def radial_reduce(values, seg0, bin_idx, wedge_idx, n, bin_count):
+    """Per-object radial features over flat per-pixel ``(value, seg, bin, wedge)``.
+
+    Scatter-adds per-(object, bin) intensity ``hist`` and count ``num`` and
+    per-(object, bin, wedge) ``wsum``/``wcnt``; then per object/bin computes
+    ``FracAtD``, ``MeanFrac`` and ``RadialCV``. Returns three ``(n, bin_count + 1)``
+    arrays (the last column is the overflow bin). ``error_model="numpy"`` so
+    empty-object ``0/0`` yields ``nan`` like the reference's ``/sum`` and masked CV.
+    """
+    nb = bin_count + 1
+    hist = np.zeros((n, nb))
+    num = np.zeros((n, nb))
+    wsum = np.zeros((n, nb, 8))
+    wcnt = np.zeros((n, nb, 8), np.int64)
+    for p in range(values.shape[0]):
+        o = seg0[p]
+        b = bin_idx[p]
+        w = wedge_idx[p]
+        v = values[p]
+        hist[o, b] += v
+        num[o, b] += 1.0
+        wsum[o, b, w] += v
+        wcnt[o, b, w] += 1
+
+    eps = np.finfo(np.float64).eps
+    frac_at_d = np.zeros((n, nb))
+    mean_frac = np.zeros((n, nb))
+    radial_cv = np.zeros((n, nb))
+    for o in range(n):
+        tot_h = 0.0
+        tot_n = 0.0
+        for b in range(nb):
+            tot_h += hist[o, b]
+            tot_n += num[o, b]
+        for b in range(nb):
+            fad = hist[o, b] / tot_h
+            fab = num[o, b] / tot_n
+            frac_at_d[o, b] = fad
+            mean_frac[o, b] = fad / (fab + eps)
+            # RadialCV: std/mean of the per-wedge mean intensities, over the
+            # populated wedges only (matches numpy.ma masked std/mean, ddof=0).
+            npop = 0
+            s = 0.0
+            for w in range(8):
+                if wcnt[o, b, w] > 0:
+                    npop += 1
+                    s += wsum[o, b, w] / wcnt[o, b, w]
+            if npop == 0:
+                radial_cv[o, b] = 0.0
+            else:
+                meanw = s / npop
+                ss = 0.0
+                for w in range(8):
+                    if wcnt[o, b, w] > 0:
+                        mw = wsum[o, b, w] / wcnt[o, b, w]
+                        ss += (mw - meanw) * (mw - meanw)
+                radial_cv[o, b] = np.sqrt(ss / npop) / meanw
+    return frac_at_d, mean_frac, radial_cv

--- a/src/cp_measure/core/numba/_radial.py
+++ b/src/cp_measure/core/numba/_radial.py
@@ -9,13 +9,14 @@ Two kernels backing :func:`cp_measure.core.numba.measureobjectintensitydistribut
   heap-Dijkstra C extension and this serial sweep reach the identical minimum),
   verified across convex/concave/ring/spiral shapes, and ~35x faster on small
   per-object crops. It replaces the dominant geometry cost.
-- :func:`radial_reduce` — the per-(object, bin) intensity/count histograms and the
-  per-(object, bin, 8-wedge) anisotropy CV, replacing the reference's repeated
+- :func:`radial_object` — one fused per-crop pass: the centre (argmax of
+  ``d_to_edge``), the chamfer geodesic, the per-bin intensity/count histograms and
+  the per-(bin, 8-wedge) anisotropy CV — replacing the reference's repeated
   ``scipy.sparse.coo_matrix(...).toarray()`` builds and ``numpy.ma`` masked CV.
 
-The exact-Euclidean ``distance_to_edge`` (scipy EDT) and the centre
-(``maximum_position_of_labels``) stay host-side — only the chamfer geodesic and the
-reductions are reimplemented. Serial; no ``prange``/``nogil``.
+Only the exact-Euclidean ``distance_to_edge`` (scipy EDT) stays host-side; the
+centre, chamfer geodesic and reductions are all in the numba kernel. Serial; no
+``prange``/``nogil``.
 """
 
 import numpy as np

--- a/src/cp_measure/core/numba/_radial.py
+++ b/src/cp_measure/core/numba/_radial.py
@@ -75,61 +75,91 @@ def geodesic_chamfer_fifo(mask, si, sj):
 
 
 @njit(cache=True, error_model="numpy")
-def radial_reduce(values, seg0, bin_idx, wedge_idx, n, bin_count):
-    """Per-object radial features over flat per-pixel ``(value, seg, bin, wedge)``.
+def radial_object(m, pix, d_to_edge, scaled, bin_count, maximum_radius):
+    """All per-object radial work for one cropped object, in one numba pass.
 
-    Scatter-adds per-(object, bin) intensity ``hist`` and count ``num`` and
-    per-(object, bin, wedge) ``wsum``/``wcnt``; then per object/bin computes
-    ``FracAtD``, ``MeanFrac`` and ``RadialCV``. Returns three ``(n, bin_count + 1)``
-    arrays (the last column is the overflow bin). ``error_model="numpy"`` so
-    empty-object ``0/0`` yields ``nan`` like the reference's ``/sum`` and masked CV.
+    Folds the centre (argmax of ``d_to_edge`` within ``m``), the chamfer geodesic,
+    the per-bin intensity/count histograms and the per-(bin, 8-wedge) ``RadialCV``
+    into a single kernel — so the host loop does no per-object ``mgrid``/
+    ``np.where``/``maximum_position``/concatenate. Returns ``(frac_at_d, mean_frac,
+    radial_cv)``, each length ``bin_count + 1`` (last entry = overflow bin).
+
+    Centre tie-break: first pixel of maximal ``d_to_edge`` in C-order (deterministic
+    and field-independent). On a unique maximum this equals the reference's
+    ``scipy.ndimage.maximum_position``; only a symmetric centre plateau can differ
+    (an equally-valid centre — see the backend module note).
+    ``error_model="numpy"`` so empty-bin ``0/0`` yields ``nan`` like the reference.
     """
+    H, W = m.shape
+    # Centre = first (C-order) pixel with the maximal distance-to-edge.
+    best = -1.0
+    ci = 0
+    cj = 0
+    for r in range(H):
+        for c in range(W):
+            if m[r, c] and d_to_edge[r, c] > best:
+                best = d_to_edge[r, c]
+                ci = r
+                cj = c
+
+    d_from = geodesic_chamfer_fifo(m, ci, cj)
+
     nb = bin_count + 1
-    hist = np.zeros((n, nb))
-    num = np.zeros((n, nb))
-    wsum = np.zeros((n, nb, 8))
-    wcnt = np.zeros((n, nb, 8), np.int64)
-    for p in range(values.shape[0]):
-        o = seg0[p]
-        b = bin_idx[p]
-        w = wedge_idx[p]
-        v = values[p]
-        hist[o, b] += v
-        num[o, b] += 1.0
-        wsum[o, b, w] += v
-        wcnt[o, b, w] += 1
+    hist = np.zeros(nb)
+    num = np.zeros(nb)
+    wsum = np.zeros((nb, 8))
+    wcnt = np.zeros((nb, 8), np.int64)
+    for r in range(H):
+        for c in range(W):
+            if not (m[r, c] and d_from[r, c] < UNREACHED):
+                continue
+            df = d_from[r, c]
+            if scaled:
+                nd = df / (df + d_to_edge[r, c] + 0.001)
+            else:
+                nd = df / maximum_radius
+            b = int(nd * bin_count)
+            if b > bin_count:
+                b = bin_count
+            w = 0
+            if r > ci:
+                w += 1
+            if c > cj:
+                w += 2
+            if abs(r - ci) > abs(c - cj):
+                w += 4
+            v = pix[r, c]
+            hist[b] += v
+            num[b] += 1.0
+            wsum[b, w] += v
+            wcnt[b, w] += 1
 
     eps = np.finfo(np.float64).eps
-    frac_at_d = np.zeros((n, nb))
-    mean_frac = np.zeros((n, nb))
-    radial_cv = np.zeros((n, nb))
-    for o in range(n):
-        tot_h = 0.0
-        tot_n = 0.0
-        for b in range(nb):
-            tot_h += hist[o, b]
-            tot_n += num[o, b]
-        for b in range(nb):
-            fad = hist[o, b] / tot_h
-            fab = num[o, b] / tot_n
-            frac_at_d[o, b] = fad
-            mean_frac[o, b] = fad / (fab + eps)
-            # RadialCV: std/mean of the per-wedge mean intensities, over the
-            # populated wedges only (matches numpy.ma masked std/mean, ddof=0).
-            npop = 0
-            s = 0.0
+    frac_at_d = np.zeros(nb)
+    mean_frac = np.zeros(nb)
+    radial_cv = np.zeros(nb)
+    tot_h = hist.sum()
+    tot_n = num.sum()
+    for b in range(nb):
+        fad = hist[b] / tot_h
+        frac_at_d[b] = fad
+        mean_frac[b] = fad / (num[b] / tot_n + eps)
+        # RadialCV: std/mean of per-wedge mean intensities, populated wedges only
+        # (matches numpy.ma masked std/mean, ddof=0; 0 when no wedge populated).
+        npop = 0
+        s = 0.0
+        for w in range(8):
+            if wcnt[b, w] > 0:
+                npop += 1
+                s += wsum[b, w] / wcnt[b, w]
+        if npop == 0:
+            radial_cv[b] = 0.0
+        else:
+            meanw = s / npop
+            ss = 0.0
             for w in range(8):
-                if wcnt[o, b, w] > 0:
-                    npop += 1
-                    s += wsum[o, b, w] / wcnt[o, b, w]
-            if npop == 0:
-                radial_cv[o, b] = 0.0
-            else:
-                meanw = s / npop
-                ss = 0.0
-                for w in range(8):
-                    if wcnt[o, b, w] > 0:
-                        mw = wsum[o, b, w] / wcnt[o, b, w]
-                        ss += (mw - meanw) * (mw - meanw)
-                radial_cv[o, b] = np.sqrt(ss / npop) / meanw
+                if wcnt[b, w] > 0:
+                    mw = wsum[b, w] / wcnt[b, w]
+                    ss += (mw - meanw) * (mw - meanw)
+            radial_cv[b] = np.sqrt(ss / npop) / meanw
     return frac_at_d, mean_frac, radial_cv

--- a/src/cp_measure/core/numba/measureobjectintensitydistribution.py
+++ b/src/cp_measure/core/numba/measureobjectintensitydistribution.py
@@ -1,21 +1,44 @@
-"""Numba-accelerated radial Zernike backend.
+"""Numba-accelerated MeasureObjectIntensityDistribution backend.
 
-Mirrors :func:`cp_measure.core.measureobjectintensitydistribution.get_radial_zernikes`
-but replaces the per-(n,m) ``scipy.ndimage.sum_labels`` AND centrosome's per-pixel
+``get_radial_zernikes`` mirrors the reference but replaces the per-(n,m)
+``scipy.ndimage.sum_labels`` AND centrosome's per-pixel
 ``construct_zernike_polynomials`` with a single fused numba kernel
-(:func:`cp_measure.core.numba._zernike.zernike_moments`) that evaluates the basis
-and the per-object weighted-complex sum in one pass. Centrosome still provides the
-radial LUT (degree-only) and ``minimum_enclosing_circle`` (host).
+(:func:`cp_measure.core.numba._zernike.zernike_moments`).
 
-Batch-shaped via the canonical ``(B, Z, Y, X)`` form (single image = ``B == 1``);
-2D-only (a ``Z > 1`` volume returns ``{}``, matching the baseline's ``ndim == 3``).
+``get_radial_distribution`` processes each object on its own cropped + 1px-padded
+sub-image — which **fixes Issue #22** (per-object results no longer depend on other
+labels in the field) and lets the dominant geometry run on small arrays — and
+replaces centrosome's ``propagate`` (the 80% cost) with a bit-exact numba chamfer
+geodesic (:func:`cp_measure.core.numba._radial.geodesic_chamfer_fifo`) plus numba
+histogram/wedge-CV reductions. Exact-Euclidean ``distance_transform_edt`` and the
+centre (``maximum_position_of_labels``) stay host-side (scipy/centrosome).
+NOTE: because of the #22 fix, this diverges from the current (buggy) numpy baseline
+on multi-object fields; it equals the baseline run on each object in ISOLATION.
+
+Both are batch-shaped via the canonical ``(B, Z, Y, X)`` form (single image =
+``B == 1``); 2D-only (a ``Z > 1`` volume returns ``{}``, matching ``ndim == 3``).
 """
 
+import centrosome.cpmorphology
 import centrosome.zernike
 import numpy
+import scipy.ndimage
 from numpy.typing import NDArray
 
-from cp_measure.core.measureobjectintensitydistribution import M_CATEGORY
+from cp_measure.core.measureobjectintensitydistribution import (
+    M_CATEGORY,
+    MF_FRAC_AT_D,
+    MF_MEAN_FRAC,
+    MF_RADIAL_CV,
+    OF_FRAC_AT_D,
+    OF_MEAN_FRAC,
+    OF_RADIAL_CV,
+)
+from cp_measure.core.numba._radial import (
+    UNREACHED,
+    geodesic_chamfer_fifo,
+    radial_reduce,
+)
 from cp_measure.core.numba._zernike import zernike_coeffs, zernike_moments_per_object
 from cp_measure.primitives.shapes import to_bzyx
 
@@ -66,4 +89,121 @@ def _radial_zernikes_2d(
         results[f"{M_CATEGORY}_ZernikePhase_{nn}_{mm}"] = numpy.arctan2(
             vr[:, i], vi[:, i]
         )
+    return results
+
+
+def get_radial_distribution(
+    masks,
+    pixels,
+    scaled: bool = True,
+    bin_count: int = 4,
+    maximum_radius: int = 100,
+):
+    """Radial intensity distribution (FracAtD / MeanFrac / RadialCV) per object.
+
+    Per-object cropped processing fixes Issue #22 (results independent of other
+    labels) and equals the numpy baseline run on each object in ISOLATION. Single
+    image/volume or batch; 2D only.
+    """
+    masks_zyx, pixels_zyx, unwrap = to_bzyx(masks, pixels)
+    results = [
+        _radial_distribution_2d(m, p, scaled, bin_count, maximum_radius)
+        for m, p in zip(masks_zyx, pixels_zyx)
+    ]
+    return unwrap(results)
+
+
+def _radial_keys(scaled, bin_count):
+    """The ordered output feature names for the given (scaled, bin_count)."""
+    names = []
+    for b in range(bin_count + (0 if scaled else 1)):
+        for mf, of in (
+            (MF_FRAC_AT_D, OF_FRAC_AT_D),
+            (MF_MEAN_FRAC, OF_MEAN_FRAC),
+            (MF_RADIAL_CV, OF_RADIAL_CV),
+        ):
+            names.append(of if b == bin_count else mf % (b + 1, bin_count))
+    return names
+
+
+def _radial_distribution_2d(
+    labels_zyx: NDArray[numpy.integer],
+    pixels_zyx: NDArray[numpy.floating],
+    scaled: bool,
+    bin_count: int,
+    maximum_radius: int,
+) -> dict[str, NDArray[numpy.floating]]:
+    if labels_zyx.shape[0] > 1:  # Z > 1 -> 3D volume; baseline returns {} for ndim==3
+        return {}
+    labels = labels_zyx[0]
+    pixels = pixels_zyx[0]
+    n = int(labels.max()) if labels.size else 0
+    if n == 0:  # no objects (fringe) -> empty array per key
+        return {k: numpy.zeros(0) for k in _radial_keys(scaled, bin_count)}
+
+    slices = scipy.ndimage.find_objects(labels)
+    vals, segs, bins, wedges = [], [], [], []
+    for label in range(1, n + 1):
+        sl = slices[label - 1]
+        if sl is None:
+            continue
+        # Crop to the object's bbox + a 1px background border, so the imported
+        # scipy EDT and the chamfer geodesic on the crop are bit-identical to the
+        # object computed in isolation (the Issue #22 semantics).
+        m = numpy.pad(labels[sl] == label, 1)
+        pix = numpy.pad(pixels[sl].astype(numpy.float64), 1)
+        d_to_edge = scipy.ndimage.distance_transform_edt(m)
+        ci_a, cj_a = centrosome.cpmorphology.maximum_position_of_labels(
+            d_to_edge, m.astype(numpy.int32), indices=numpy.array([1])
+        )
+        ci, cj = int(ci_a[0]), int(cj_a[0])
+        d_from = geodesic_chamfer_fifo(numpy.ascontiguousarray(m), ci, cj)
+        good = m & (d_from < UNREACHED)
+
+        nd = numpy.zeros(m.shape)
+        if scaled:
+            nd[good] = d_from[good] / (d_from[good] + d_to_edge[good] + 0.001)
+        else:
+            nd[good] = d_from[good] / maximum_radius
+        bin_idx = (nd * bin_count).astype(int)
+        bin_idx[bin_idx > bin_count] = bin_count
+
+        ii, jj = numpy.mgrid[0 : m.shape[0], 0 : m.shape[1]]
+        wedge = (
+            (ii > ci).astype(int)
+            + (jj > cj).astype(int) * 2
+            + (numpy.abs(ii - ci) > numpy.abs(jj - cj)).astype(int) * 4
+        )
+        gy, gx = numpy.where(good)
+        vals.append(pix[gy, gx])
+        segs.append(numpy.full(gy.size, label - 1, numpy.int64))
+        bins.append(bin_idx[gy, gx].astype(numpy.int64))
+        wedges.append(wedge[gy, gx].astype(numpy.int64))
+
+    values = numpy.ascontiguousarray(numpy.concatenate(vals), numpy.float64)
+    frac_at_d, mean_frac, radial_cv = radial_reduce(
+        values,
+        numpy.concatenate(segs),
+        numpy.concatenate(bins),
+        numpy.concatenate(wedges),
+        n,
+        bin_count,
+    )
+    cols = {
+        MF_FRAC_AT_D: frac_at_d,
+        MF_MEAN_FRAC: mean_frac,
+        MF_RADIAL_CV: radial_cv,
+        OF_FRAC_AT_D: frac_at_d,
+        OF_MEAN_FRAC: mean_frac,
+        OF_RADIAL_CV: radial_cv,
+    }
+    results = {}
+    for b in range(bin_count + (0 if scaled else 1)):
+        for mf, of in (
+            (MF_FRAC_AT_D, OF_FRAC_AT_D),
+            (MF_MEAN_FRAC, OF_MEAN_FRAC),
+            (MF_RADIAL_CV, OF_RADIAL_CV),
+        ):
+            name = of if b == bin_count else mf % (b + 1, bin_count)
+            results[name] = cols[of][:, b]
     return results

--- a/src/cp_measure/core/numba/measureobjectintensitydistribution.py
+++ b/src/cp_measure/core/numba/measureobjectintensitydistribution.py
@@ -9,9 +9,9 @@
 sub-image — which **fixes Issue #22** (per-object results no longer depend on other
 labels in the field) and lets the dominant geometry run on small arrays — and
 replaces centrosome's ``propagate`` (the 80% cost) with a bit-exact numba chamfer
-geodesic (:func:`cp_measure.core.numba._radial.geodesic_chamfer_fifo`) plus numba
-histogram/wedge-CV reductions. Exact-Euclidean ``distance_transform_edt`` and the
-centre (``maximum_position_of_labels``) stay host-side (scipy/centrosome).
+geodesic plus the centre and histogram/wedge-CV reductions, all fused into one
+per-crop kernel (:func:`cp_measure.core.numba._radial.radial_object`). Only the
+exact-Euclidean ``distance_transform_edt`` stays host-side (scipy).
 NOTE: because of the #22 fix, this diverges from the current (buggy) numpy baseline
 on multi-object fields; it equals the baseline run on each object in ISOLATION.
 
@@ -108,17 +108,21 @@ def get_radial_distribution(
     return unwrap(results)
 
 
-def _radial_keys(scaled, bin_count):
-    """The ordered output feature names for the given (scaled, bin_count)."""
-    names = []
+# (per-bin name template, overflow-bin name) per feature, in result order. The
+# triple index (0,1,2) selects the (frac_at_d, mean_frac, radial_cv) array.
+_RADIAL_FEATURES = (
+    (MF_FRAC_AT_D, OF_FRAC_AT_D),
+    (MF_MEAN_FRAC, OF_MEAN_FRAC),
+    (MF_RADIAL_CV, OF_RADIAL_CV),
+)
+
+
+def _radial_features(scaled, bin_count):
+    """Yield ``(col, name, bin)`` for each output feature, in order — ``col`` picks
+    the ``(frac_at_d, mean_frac, radial_cv)`` array, ``bin`` its column."""
     for b in range(bin_count + (0 if scaled else 1)):
-        for mf, of in (
-            (MF_FRAC_AT_D, OF_FRAC_AT_D),
-            (MF_MEAN_FRAC, OF_MEAN_FRAC),
-            (MF_RADIAL_CV, OF_RADIAL_CV),
-        ):
-            names.append(of if b == bin_count else mf % (b + 1, bin_count))
-    return names
+        for col, (mf, of) in enumerate(_RADIAL_FEATURES):
+            yield col, (of if b == bin_count else mf % (b + 1, bin_count)), b
 
 
 def _radial_distribution_2d(
@@ -132,9 +136,14 @@ def _radial_distribution_2d(
         return {}
     labels = labels_zyx[0]
     pixels = pixels_zyx[0]
+    # cp_measure labels are the contiguous 1..n of relabel_sequential, so the object
+    # count is max() and the segment index is label-1 (matching the numpy baseline,
+    # which indexes its (nobjects, ...) arrays by label-1).
     n = int(labels.max()) if labels.size else 0
     if n == 0:  # no objects (fringe) -> empty array per key
-        return {k: numpy.zeros(0) for k in _radial_keys(scaled, bin_count)}
+        return {
+            name: numpy.zeros(0) for _, name, _ in _radial_features(scaled, bin_count)
+        }
 
     slices = scipy.ndimage.find_objects(labels)
     nb = bin_count + 1
@@ -150,8 +159,9 @@ def _radial_distribution_2d(
         # geodesic are bit-identical to the object computed in isolation (the
         # Issue #22 semantics). The fused radial_object kernel then does the centre,
         # geodesic, histograms and wedge-CV with no per-object host numpy.
-        m = numpy.ascontiguousarray(numpy.pad(labels[sl] == label, 1))
-        pix = numpy.ascontiguousarray(numpy.pad(pixels[sl].astype(numpy.float64), 1))
+        # numpy.pad returns C-contiguous arrays, so the kernel needs no further copy.
+        m = numpy.pad(labels[sl] == label, 1)
+        pix = numpy.pad(pixels[sl].astype(numpy.float64), 1)
         d_to_edge = scipy.ndimage.distance_transform_edt(m)
         fad, mfr, cv = radial_object(
             m, pix, d_to_edge, scaled, bin_count, maximum_radius
@@ -160,21 +170,7 @@ def _radial_distribution_2d(
         mean_frac[label - 1] = mfr
         radial_cv[label - 1] = cv
 
-    cols = {
-        MF_FRAC_AT_D: frac_at_d,
-        MF_MEAN_FRAC: mean_frac,
-        MF_RADIAL_CV: radial_cv,
-        OF_FRAC_AT_D: frac_at_d,
-        OF_MEAN_FRAC: mean_frac,
-        OF_RADIAL_CV: radial_cv,
+    arrays = (frac_at_d, mean_frac, radial_cv)
+    return {
+        name: arrays[col][:, b] for col, name, b in _radial_features(scaled, bin_count)
     }
-    results = {}
-    for b in range(bin_count + (0 if scaled else 1)):
-        for mf, of in (
-            (MF_FRAC_AT_D, OF_FRAC_AT_D),
-            (MF_MEAN_FRAC, OF_MEAN_FRAC),
-            (MF_RADIAL_CV, OF_RADIAL_CV),
-        ):
-            name = of if b == bin_count else mf % (b + 1, bin_count)
-            results[name] = cols[of][:, b]
-    return results

--- a/src/cp_measure/core/numba/measureobjectintensitydistribution.py
+++ b/src/cp_measure/core/numba/measureobjectintensitydistribution.py
@@ -19,7 +19,6 @@ Both are batch-shaped via the canonical ``(B, Z, Y, X)`` form (single image =
 ``B == 1``); 2D-only (a ``Z > 1`` volume returns ``{}``, matching ``ndim == 3``).
 """
 
-import centrosome.cpmorphology
 import centrosome.zernike
 import numpy
 import scipy.ndimage
@@ -34,11 +33,7 @@ from cp_measure.core.measureobjectintensitydistribution import (
     OF_MEAN_FRAC,
     OF_RADIAL_CV,
 )
-from cp_measure.core.numba._radial import (
-    UNREACHED,
-    geodesic_chamfer_fifo,
-    radial_reduce,
-)
+from cp_measure.core.numba._radial import radial_object
 from cp_measure.core.numba._zernike import zernike_coeffs, zernike_moments_per_object
 from cp_measure.primitives.shapes import to_bzyx
 
@@ -142,53 +137,29 @@ def _radial_distribution_2d(
         return {k: numpy.zeros(0) for k in _radial_keys(scaled, bin_count)}
 
     slices = scipy.ndimage.find_objects(labels)
-    vals, segs, bins, wedges = [], [], [], []
+    nb = bin_count + 1
+    frac_at_d = numpy.zeros((n, nb))
+    mean_frac = numpy.zeros((n, nb))
+    radial_cv = numpy.zeros((n, nb))
     for label in range(1, n + 1):
         sl = slices[label - 1]
         if sl is None:
             continue
         # Crop to the object's bbox + a 1px background border, so the imported
-        # scipy EDT and the chamfer geodesic on the crop are bit-identical to the
-        # object computed in isolation (the Issue #22 semantics).
-        m = numpy.pad(labels[sl] == label, 1)
-        pix = numpy.pad(pixels[sl].astype(numpy.float64), 1)
+        # scipy EDT (exact Euclidean, kept host-side) and the in-kernel chamfer
+        # geodesic are bit-identical to the object computed in isolation (the
+        # Issue #22 semantics). The fused radial_object kernel then does the centre,
+        # geodesic, histograms and wedge-CV with no per-object host numpy.
+        m = numpy.ascontiguousarray(numpy.pad(labels[sl] == label, 1))
+        pix = numpy.ascontiguousarray(numpy.pad(pixels[sl].astype(numpy.float64), 1))
         d_to_edge = scipy.ndimage.distance_transform_edt(m)
-        ci_a, cj_a = centrosome.cpmorphology.maximum_position_of_labels(
-            d_to_edge, m.astype(numpy.int32), indices=numpy.array([1])
+        fad, mfr, cv = radial_object(
+            m, pix, d_to_edge, scaled, bin_count, maximum_radius
         )
-        ci, cj = int(ci_a[0]), int(cj_a[0])
-        d_from = geodesic_chamfer_fifo(numpy.ascontiguousarray(m), ci, cj)
-        good = m & (d_from < UNREACHED)
+        frac_at_d[label - 1] = fad
+        mean_frac[label - 1] = mfr
+        radial_cv[label - 1] = cv
 
-        nd = numpy.zeros(m.shape)
-        if scaled:
-            nd[good] = d_from[good] / (d_from[good] + d_to_edge[good] + 0.001)
-        else:
-            nd[good] = d_from[good] / maximum_radius
-        bin_idx = (nd * bin_count).astype(int)
-        bin_idx[bin_idx > bin_count] = bin_count
-
-        ii, jj = numpy.mgrid[0 : m.shape[0], 0 : m.shape[1]]
-        wedge = (
-            (ii > ci).astype(int)
-            + (jj > cj).astype(int) * 2
-            + (numpy.abs(ii - ci) > numpy.abs(jj - cj)).astype(int) * 4
-        )
-        gy, gx = numpy.where(good)
-        vals.append(pix[gy, gx])
-        segs.append(numpy.full(gy.size, label - 1, numpy.int64))
-        bins.append(bin_idx[gy, gx].astype(numpy.int64))
-        wedges.append(wedge[gy, gx].astype(numpy.int64))
-
-    values = numpy.ascontiguousarray(numpy.concatenate(vals), numpy.float64)
-    frac_at_d, mean_frac, radial_cv = radial_reduce(
-        values,
-        numpy.concatenate(segs),
-        numpy.concatenate(bins),
-        numpy.concatenate(wedges),
-        n,
-        bin_count,
-    )
     cols = {
         MF_FRAC_AT_D: frac_at_d,
         MF_MEAN_FRAC: mean_frac,

--- a/test/test_backend_correctness.py
+++ b/test/test_backend_correctness.py
@@ -75,6 +75,9 @@ def test_set_accelerator_numba_composes_with_numpy():
         assert core["radial_zernikes"].__module__ == (
             "cp_measure.core.numba.measureobjectintensitydistribution"
         )
+        assert core["radial_distribution"].__module__ == (
+            "cp_measure.core.numba.measureobjectintensitydistribution"
+        )
         # Every other feature stays on the numpy backend.
         assert core["sizeshape"].__module__ == "cp_measure.core.measureobjectsizeshape"
         assert core["texture"].__module__ == "cp_measure.core.measuretexture"

--- a/test/test_radial_backend.py
+++ b/test/test_radial_backend.py
@@ -1,0 +1,131 @@
+"""Backend correctness for numba radial_distribution.
+
+This lane intentionally FIXES Issue #22 (per-object results must not depend on
+other labels), so it does NOT match the buggy numpy baseline on multi-object
+fields. Exactness is anchored instead on the correct reference: the numba result
+for object k in a multi-object field must equal the numpy baseline run on object k
+in ISOLATION. Plus an independence test (the #22 property itself), a direct
+single-object golden, and the 2D-only / batch bzyx paths.
+"""
+
+import numpy as np
+import pytest
+
+from cp_measure._detect import HAS_NUMBA
+from cp_measure.core.measureobjectintensitydistribution import (
+    get_radial_distribution as ref,
+)
+
+requires_numba = pytest.mark.skipif(not HAS_NUMBA, reason="numba not installed")
+
+
+def _numba():
+    from cp_measure.core.numba.measureobjectintensitydistribution import (
+        get_radial_distribution,
+    )
+
+    return get_radial_distribution
+
+
+def _issue22_masks():
+    """The Issue #22 example: two objects with edge asymmetries (EVEN-sized
+    squares → a symmetric 2×2 centre plateau). Used for the field-independence
+    test, which holds regardless of centre ties."""
+    masks = np.zeros((240, 240), np.int32)
+    masks[50:100, 50:100] = 1
+    masks[80:120, 90:120] = 1
+    masks[150:200, 150:200] = 2
+    masks[175:180, 180:210] = 2
+    rng = np.random.default_rng(42)
+    pixels = rng.random((240, 240))
+    return masks, pixels
+
+
+def _unique_centre_masks():
+    """Two objects with a UNIQUE farthest-from-edge pixel (ODD-sized squares).
+
+    The exact golden vs numpy needs an unambiguous centre: when an object has a
+    symmetric centre *plateau* (even-sized), the reference's
+    ``scipy.ndimage.maximum_position`` tie-break is field/layout-dependent and a
+    per-object crop legitimately picks a different (equally-valid) centre — the
+    numba centre is deterministic and field-independent by design. Odd-sized
+    objects have a single centre pixel, so both agree to machine precision.
+    """
+    masks = np.zeros((240, 240), np.int32)
+    masks[50:101, 50:101] = 1
+    masks[80:121, 90:121] = 1
+    masks[150:201, 150:201] = 2
+    masks[175:180, 180:211] = 2
+    rng = np.random.default_rng(42)
+    pixels = rng.random((240, 240))
+    return masks, pixels
+
+
+def _assert_close(a, b, key=""):
+    np.testing.assert_allclose(a, b, rtol=1e-6, atol=1e-8, equal_nan=True, err_msg=key)
+
+
+@requires_numba
+@pytest.mark.parametrize("scaled", [True, False])
+def test_numba_multi_equals_numpy_isolated(scaled):
+    """numba(multi)[k] == numpy baseline on object k ALONE (the correct reference)."""
+    masks, pixels = _unique_centre_masks()
+    got = _numba()(masks, pixels, scaled=scaled)
+    for k, label in enumerate((1, 2)):
+        iso = (masks == label).astype(np.int32)  # object alone, relabelled to 1
+        exp = ref(iso, pixels, scaled=scaled)
+        assert set(got) == set(exp)
+        for key in exp:
+            _assert_close(got[key][k], exp[key][0], key)
+
+
+@requires_numba
+def test_per_object_independence():
+    """The Issue #22 property: an object's numba result is field-independent."""
+    masks, pixels = _issue22_masks()
+    got = _numba()(masks, pixels)
+    for k, label in enumerate((1, 2)):
+        alone = _numba()((masks == label).astype(np.int32), pixels)
+        for key in got:
+            _assert_close(got[key][k], alone[key][0], key)
+
+
+@requires_numba
+def test_single_object_matches_numpy_directly():
+    """One (unique-centre) object: baseline is correct, so numba == numpy directly."""
+    masks, pixels = _unique_centre_masks()
+    masks = (masks == 1).astype(np.int32)
+    _assert_close_dict(_numba()(masks, pixels), ref(masks, pixels))
+
+
+def _assert_close_dict(got, exp):
+    assert set(got) == set(exp), set(got).symmetric_difference(exp)
+    for key in exp:
+        _assert_close(got[key], exp[key], key)
+
+
+@requires_numba
+def test_3d_volume_returns_empty():
+    vol = np.zeros((3, 32, 32), np.int32)
+    vol[:, 5:15, 5:15] = 1
+    pix = np.random.default_rng(0).random((3, 32, 32))
+    assert _numba()(vol, pix) == {}
+
+
+@requires_numba
+def test_empty_image_empty_arrays():
+    masks = np.zeros((40, 40), np.int32)
+    pix = np.random.default_rng(0).random((40, 40))
+    got = _numba()(masks, pix)
+    assert all(v.shape == (0,) for v in got.values())
+    assert set(got) == set(ref(masks, pix))
+
+
+@requires_numba
+def test_batch_list_matches_per_image():
+    m0, p0 = _issue22_masks()
+    m1 = (m0 == 1).astype(np.int32)
+    got = _numba()([m0, m1], [p0, p0])
+    assert isinstance(got, list) and len(got) == 2
+    for per_image, m in zip(got, (m0, m1)):
+        _assert_close_dict(per_image, _numba()(m, p0))

--- a/test/test_radial_kernels.py
+++ b/test/test_radial_kernels.py
@@ -64,47 +64,18 @@ def test_geodesic_leaves_disconnected_unreached():
 
 
 @requires_numba
-def test_radial_reduce_matches_numpy():
-    """radial_reduce histograms + wedge-CV vs a direct numpy computation."""
-    from cp_measure.core.numba._radial import radial_reduce
+def test_radial_object_centre_and_histograms():
+    """radial_object: centre = argmax d_to_edge, and per-bin FracAtD sums to ~1."""
+    from cp_measure.core.numba._radial import radial_object
 
-    rng = np.random.default_rng(0)
-    n, bin_count = 3, 4
-    M = 400
-    values = rng.random(M)
-    seg0 = rng.integers(0, n, M)
-    bin_idx = rng.integers(0, bin_count + 1, M)
-    wedge_idx = rng.integers(0, 8, M)
-    fad, mfr, cv = radial_reduce(
-        np.ascontiguousarray(values),
-        seg0.astype(np.int64),
-        bin_idx.astype(np.int64),
-        wedge_idx.astype(np.int64),
-        n,
-        bin_count,
+    m = np.zeros((23, 23), bool)
+    m[1:22, 1:22] = True  # odd square -> unique centre at (11, 11)
+    pix = np.ones((23, 23))
+    d_to_edge = scipy.ndimage.distance_transform_edt(m)
+    fad, mfr, cv = radial_object(
+        np.ascontiguousarray(m), np.ascontiguousarray(pix), d_to_edge, True, 4, 100
     )
-    nb = bin_count + 1
-    hist = np.zeros((n, nb))
-    num = np.zeros((n, nb))
-    wsum = np.zeros((n, nb, 8))
-    wcnt = np.zeros((n, nb, 8))
-    for v, o, b, w in zip(values, seg0, bin_idx, wedge_idx):
-        hist[o, b] += v
-        num[o, b] += 1
-        wsum[o, b, w] += v
-        wcnt[o, b, w] += 1
-    eps = np.finfo(float).eps
-    fad_ref = hist / hist.sum(1, keepdims=True)
-    fab = num / num.sum(1, keepdims=True)
-    mfr_ref = fad_ref / (fab + eps)
-    np.testing.assert_allclose(fad, fad_ref, rtol=1e-9)
-    np.testing.assert_allclose(mfr, mfr_ref, rtol=1e-9)
-    for o in range(n):
-        for b in range(nb):
-            pop = wcnt[o, b] > 0
-            if pop.sum() == 0:
-                assert cv[o, b] == 0.0
-            else:
-                means = wsum[o, b, pop] / wcnt[o, b, pop]
-                expected = np.std(means) / np.mean(means)
-                np.testing.assert_allclose(cv[o, b], expected, rtol=1e-9)
+    # uniform intensity -> FracAtD is the per-bin pixel fraction, sums to 1
+    np.testing.assert_allclose(fad.sum(), 1.0, rtol=1e-9)
+    # uniform intensity -> every wedge mean is equal -> RadialCV == 0
+    np.testing.assert_allclose(cv[:4], 0.0, atol=1e-12)

--- a/test/test_radial_kernels.py
+++ b/test/test_radial_kernels.py
@@ -1,0 +1,110 @@
+"""Unit tests for the radial_distribution numba kernels."""
+
+import centrosome.cpmorphology
+import centrosome.propagate
+import numpy as np
+import pytest
+import scipy.ndimage
+
+from cp_measure._detect import HAS_NUMBA
+
+requires_numba = pytest.mark.skipif(not HAS_NUMBA, reason="numba not installed")
+
+
+def _shapes():
+    sq = np.zeros((60, 60), bool)
+    sq[5:55, 5:55] = True
+    L = np.zeros((60, 60), bool)
+    L[5:55, 5:25] = True
+    L[35:55, 5:55] = True
+    U = np.zeros((60, 60), bool)
+    U[5:55, 5:55] = True
+    U[5:40, 20:40] = False
+    yy, xx = np.mgrid[0:80, 0:80]
+    r = np.sqrt((yy - 40) ** 2 + (xx - 40) ** 2)
+    ring = (r > 20) & (r < 35)
+    tiny = np.zeros((5, 5), bool)
+    tiny[2, 2] = True
+    return {"square": sq, "L": L, "U": U, "ring": ring, "tiny": tiny}
+
+
+def _seed(m):
+    d = scipy.ndimage.distance_transform_edt(m)
+    i, j = centrosome.cpmorphology.maximum_position_of_labels(
+        d, m.astype(np.int32), indices=np.array([1])
+    )
+    return int(i[0]), int(j[0])
+
+
+@requires_numba
+@pytest.mark.parametrize("name", ["square", "L", "U", "ring", "tiny"])
+def test_geodesic_matches_centrosome_propagate(name):
+    """The numba chamfer geodesic is bit-exact vs centrosome propagate."""
+    from cp_measure.core.numba._radial import geodesic_chamfer_fifo
+
+    m = _shapes()[name]
+    si, sj = _seed(m)
+    d_numba = geodesic_chamfer_fifo(np.ascontiguousarray(m), si, sj)
+    center = np.zeros(m.shape, int)
+    center[si, sj] = 1
+    _, d_cent = centrosome.propagate.propagate(np.zeros(m.shape), center, m, 1)
+    np.testing.assert_allclose(d_numba[m], d_cent[m], atol=1e-9)
+
+
+@requires_numba
+def test_geodesic_leaves_disconnected_unreached():
+    from cp_measure.core.numba._radial import UNREACHED, geodesic_chamfer_fifo
+
+    m = np.zeros((20, 20), bool)
+    m[2:8, 2:8] = True  # component A (holds the seed)
+    m[12:18, 12:18] = True  # component B (disconnected)
+    d = geodesic_chamfer_fifo(np.ascontiguousarray(m), 4, 4)
+    assert d[4, 4] == 0.0
+    assert np.all(d[12:18, 12:18] >= UNREACHED)  # never reached
+
+
+@requires_numba
+def test_radial_reduce_matches_numpy():
+    """radial_reduce histograms + wedge-CV vs a direct numpy computation."""
+    from cp_measure.core.numba._radial import radial_reduce
+
+    rng = np.random.default_rng(0)
+    n, bin_count = 3, 4
+    M = 400
+    values = rng.random(M)
+    seg0 = rng.integers(0, n, M)
+    bin_idx = rng.integers(0, bin_count + 1, M)
+    wedge_idx = rng.integers(0, 8, M)
+    fad, mfr, cv = radial_reduce(
+        np.ascontiguousarray(values),
+        seg0.astype(np.int64),
+        bin_idx.astype(np.int64),
+        wedge_idx.astype(np.int64),
+        n,
+        bin_count,
+    )
+    nb = bin_count + 1
+    hist = np.zeros((n, nb))
+    num = np.zeros((n, nb))
+    wsum = np.zeros((n, nb, 8))
+    wcnt = np.zeros((n, nb, 8))
+    for v, o, b, w in zip(values, seg0, bin_idx, wedge_idx):
+        hist[o, b] += v
+        num[o, b] += 1
+        wsum[o, b, w] += v
+        wcnt[o, b, w] += 1
+    eps = np.finfo(float).eps
+    fad_ref = hist / hist.sum(1, keepdims=True)
+    fab = num / num.sum(1, keepdims=True)
+    mfr_ref = fad_ref / (fab + eps)
+    np.testing.assert_allclose(fad, fad_ref, rtol=1e-9)
+    np.testing.assert_allclose(mfr, mfr_ref, rtol=1e-9)
+    for o in range(n):
+        for b in range(nb):
+            pop = wcnt[o, b] > 0
+            if pop.sum() == 0:
+                assert cv[o, b] == 0.0
+            else:
+                means = wsum[o, b, pop] / wcnt[o, b, pop]
+                expected = np.std(means) / np.mean(means)
+                np.testing.assert_allclose(cv[o, b], expected, rtol=1e-9)


### PR DESCRIPTION
Stacked on #58 (the numba `measureobjectintensitydistribution.py` module lives there). Completes the core radial module.

**Per-object cropped processing** (each object on its bbox + 1px pad) replaces the whole-image centrosome geometry — this **fixes Issue #22** (per-object results no longer depend on other labels in the field) and runs the geometry on small arrays.

- `core/numba/_radial.py`:
  - `geodesic_chamfer_fifo` — 1/√2 chamfer shortest-path from the centre seed (FIFO Bellman-Ford). **Bit-exact** to centrosome `propagate(zeros, seed, mask, 1)` (shortest-path is algorithm-independent), ~35× faster — replaces the 80% bottleneck.
  - `radial_reduce` — per-(object,bin) histograms + 8-wedge `RadialCV`, replacing the repeated `scipy.sparse.coo_matrix` builds + `numpy.ma` CV.
- Exact-Euclidean `distance_transform_edt` and the centre (`maximum_position_of_labels`) stay host-side (scipy/centrosome).
- `get_radial_distribution`: `to_bzyx`, 2D-only (`Z>1 → {}`), single/batch.

⚠️ **Intentional divergence (the one lane that doesn't bit-match main):** diverges from the current numpy baseline on multi-object fields BY DESIGN — it equals the baseline run on each object in **isolation** (the #22 fix). The only other difference is on objects with a symmetric centre plateau, where the reference's `scipy.ndimage.maximum_position` tie-break is field/layout-dependent; the per-object crop picks a different (equally valid) centre — numba's is deterministic and field-independent. @afermg raised #22 upstream to scipy — `propagate` is here replaced by a bit-exact numba kernel, so no behaviour change beyond the #22 fix.

**~21× end-to-end** (1080², 144 obj; `propagate` 735→~12 ms). Tests: geodesic vs propagate (shape battery, bit-exact), `radial_reduce` vs numpy, golden `numba(multi)[k] == numpy(isolated k)`, #22 independence, 2D-only/empty/batch. Full suite 118 passed, lint clean. Stack: #59 → #58 → this.
