### PR TITLE
feat(intensity): `legacy` percentile-convention toggle (numpy + numba)

### DIFF
--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -118,8 +118,8 @@ def get_core_measurements(legacy: bool = False) -> dict[str, Callable]:
 
 def get_core_measurements_3d(legacy: bool = False) -> dict[str, Callable]:
     """Return only measurements that support 3D input (see ``legacy`` above)."""
-    core = {k: _dispatch("core")[k] for k in _3D_FEATURES}
-    return _apply_legacy(core, legacy)
+    core = _dispatch("core")
+    return _apply_legacy({k: core[k] for k in _3D_FEATURES}, legacy)
 
 
 def get_correlation_measurements() -> dict[str, Callable]:

--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -3,6 +3,7 @@ Wrapper to fetch measurement functions in bulk. We are keeping the ugly filename
 match the original names. This may change in the future.
 """
 
+from functools import partial
 from typing import Callable
 
 from cp_measure.core import (
@@ -88,14 +89,37 @@ def _dispatch(name: str) -> dict[str, Callable]:
     )
 
 
-def get_core_measurements() -> dict[str, Callable]:
-    return _dispatch("core")
+# Features whose result honours the `legacy` percentile convention (see
+# cp_measure.core.measureobjectintensity.get_intensity). Extend as more lanes
+# gain a legacy/new split.
+_LEGACY_FEATURES = ("intensity",)
 
 
-def get_core_measurements_3d() -> dict[str, Callable]:
-    """Return only measurements that support 3D input."""
-    core = _dispatch("core")
-    return {k: core[k] for k in _3D_FEATURES}
+def _apply_legacy(core: dict[str, Callable], legacy: bool) -> dict[str, Callable]:
+    """Bind ``legacy=True`` into the features that honour it; no-op when False."""
+    if not legacy:
+        return core
+    return {
+        name: (partial(fn, legacy=True) if name in _LEGACY_FEATURES else fn)
+        for name, fn in core.items()
+    }
+
+
+def get_core_measurements(legacy: bool = False) -> dict[str, Callable]:
+    """Core per-object measurement functions.
+
+    ``legacy`` (default False) selects the original CellProfiler ``n*q`` percentile
+    convention for the intensity quartile/MAD features instead of the default
+    ``numpy.percentile`` one; see
+    :func:`cp_measure.core.measureobjectintensity.get_intensity`.
+    """
+    return _apply_legacy(_dispatch("core"), legacy)
+
+
+def get_core_measurements_3d(legacy: bool = False) -> dict[str, Callable]:
+    """Return only measurements that support 3D input (see ``legacy`` above)."""
+    core = {k: _dispatch("core")[k] for k in _3D_FEATURES}
+    return _apply_legacy(core, legacy)
 
 
 def get_correlation_measurements() -> dict[str, Callable]:

--- a/src/cp_measure/core/measureobjectintensity.py
+++ b/src/cp_measure/core/measureobjectintensity.py
@@ -278,12 +278,13 @@ def get_intensity(
             # Interpolation position: n*q (legacy CellProfiler) vs (n-1)*q
             # (numpy.percentile 'linear'). The clamp boundary stays indices+areas-1.
             span = areas if legacy else (areas - 1)
+            float_indices = indices.astype(float)
             for dest, fraction in (
                 (lower_quartile_intensity, 1.0 / 4.0),
                 (median_intensity, 1.0 / 2.0),
                 (upper_quartile_intensity, 3.0 / 4.0),
             ):
-                qindex = indices.astype(float) + span * fraction
+                qindex = float_indices + span * fraction
                 qfraction = qindex - numpy.floor(qindex)
                 qindex = qindex.astype(int)
                 qmask = qindex < indices + areas - 1
@@ -307,7 +308,7 @@ def get_intensity(
             order = numpy.lexsort((madimg, llabels))
             # legacy: (1/ndim)-quantile at n*frac; new: textbook median at (n-1)*0.5
             mad_fraction = (1.0 / pixels.ndim) if legacy else 0.5
-            qindex = indices.astype(float) + span * mad_fraction
+            qindex = float_indices + span * mad_fraction
             qfraction = qindex - numpy.floor(qindex)
             qindex = qindex.astype(int)
             qmask = qindex < indices + areas - 1

--- a/src/cp_measure/core/measureobjectintensity.py
+++ b/src/cp_measure/core/measureobjectintensity.py
@@ -123,9 +123,17 @@ def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
+    legacy: bool = False,
 ) -> dict[str, NDArray[numpy.floating]]:
-    """
-    masks is a labeled array where 0 are background images.
+    """masks is a labeled array where 0 are background images.
+
+    ``legacy`` selects the percentile convention for the four quantile features
+    (LowerQuartile / Median / UpperQuartile / MAD). When False (default) quartiles
+    use the ``numpy.percentile`` 'linear' (``(n-1)*q``) position and MAD is the
+    textbook ``median(|x - median(x)|)``. When True, reproduce the original
+    cp_measure / CellProfiler behavior: quartiles at the ``n*q`` position and MAD as
+    the ``(1/ndim)``-quantile of ``|x - median(x)|``. All other features are
+    identical either way.
     """
     masked_image = pixels
 
@@ -267,12 +275,15 @@ def get_intensity(
             order = numpy.lexsort((limg, llabels))
             areas = lcount.astype(int)
             indices = numpy.cumsum(areas) - areas
+            # Interpolation position: n*q (legacy CellProfiler) vs (n-1)*q
+            # (numpy.percentile 'linear'). The clamp boundary stays indices+areas-1.
+            span = areas if legacy else (areas - 1)
             for dest, fraction in (
                 (lower_quartile_intensity, 1.0 / 4.0),
                 (median_intensity, 1.0 / 2.0),
                 (upper_quartile_intensity, 3.0 / 4.0),
             ):
-                qindex = indices.astype(float) + areas * fraction
+                qindex = indices.astype(float) + span * fraction
                 qfraction = qindex - numpy.floor(qindex)
                 qindex = qindex.astype(int)
                 qmask = qindex < indices + areas - 1
@@ -294,7 +305,9 @@ def get_intensity(
             #
             madimg = numpy.abs(limg - median_intensity[llabels - 1])
             order = numpy.lexsort((madimg, llabels))
-            qindex = indices.astype(float) + areas / pixels.ndim
+            # legacy: (1/ndim)-quantile at n*frac; new: textbook median at (n-1)*0.5
+            mad_fraction = (1.0 / pixels.ndim) if legacy else 0.5
+            qindex = indices.astype(float) + span * mad_fraction
             qfraction = qindex - numpy.floor(qindex)
             qindex = qindex.astype(int)
             qmask = qindex < indices + areas - 1

--- a/src/cp_measure/core/numba/measureobjectintensity.py
+++ b/src/cp_measure/core/numba/measureobjectintensity.py
@@ -54,8 +54,15 @@ def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
+    legacy: bool = False,
 ) -> dict[str, NDArray[numpy.floating]]:
-    """masks is a labeled array where 0 are background."""
+    """masks is a labeled array where 0 are background.
+
+    ``legacy`` selects the percentile convention for the quartile/median/MAD
+    features: ``False`` (default) uses ``numpy.percentile`` ('linear') quartiles and
+    the textbook median MAD; ``True`` reproduces the original CellProfiler ``n*q``
+    quartiles and the ``(1/ndim)``-quantile MAD.
+    """
     orig_ndim = pixels.ndim
 
     masked_image = pixels
@@ -132,7 +139,7 @@ def get_intensity(
             median_intensity,
             upper_quartile_intensity,
             mad_intensity,
-        ) = segment_quantiles(values, seg0, count, nobjects, 1.0 / orig_ndim)
+        ) = segment_quantiles(values, seg0, count, nobjects, 1.0 / orig_ndim, legacy)
 
     if edge_measurements:
         integrated_intensity_edge = numpy.zeros(nobjects)

--- a/src/cp_measure/featurizer.py
+++ b/src/cp_measure/featurizer.py
@@ -28,6 +28,7 @@ def make_featurizer_config(
     channels: list[str] | None = None,
     *,
     objects: list[str] | None = None,
+    legacy: bool = False,
     intensity: bool = True,
     intensity_params: dict | None = None,
     texture: bool = True,
@@ -65,6 +66,12 @@ def make_featurizer_config(
         when there are 10 or more channels).
     objects : list[str], optional
         Names for each object mask.  Defaults to ``["object"]``.
+    legacy : bool, default False
+        Select the percentile convention for the intensity quartile/MAD features.
+        ``False`` uses the ``numpy.percentile`` ('linear') quartiles + textbook
+        median MAD; ``True`` reproduces the original CellProfiler ``n*q`` quartiles
+        + ``(1/ndim)``-quantile MAD. Forwarded to the intensity backend; all other
+        features are unaffected.
     intensity, texture, granularity, radial_distribution, radial_zernikes,
     sizeshape, zernike, feret : bool
         Enable / disable individual feature groups.
@@ -129,6 +136,7 @@ def make_featurizer_config(
     return {
         "channels": list(channels) if channels is not None else None,
         "objects": list(objects),
+        "legacy": legacy,
         "intensity": intensity,
         "intensity_params": intensity_params if intensity_params is not None else {},
         "texture": texture,
@@ -214,7 +222,12 @@ def featurize(
     )
 
     is_3d = image.ndim == 4
-    core_funcs = get_core_measurements_3d() if is_3d else get_core_measurements()
+    legacy = config.get("legacy", False)
+    core_funcs = (
+        get_core_measurements_3d(legacy=legacy)
+        if is_3d
+        else get_core_measurements(legacy=legacy)
+    )
     corr_funcs = get_correlation_measurements()
 
     if is_3d:

--- a/src/cp_measure/primitives/_segment_numba.py
+++ b/src/cp_measure/primitives/_segment_numba.py
@@ -229,8 +229,5 @@ def segment_quantiles(values, seg0, counts, n, mad_frac, legacy):
         ad = np.abs(seg - med[k])
         ad.sort()
         # legacy: (1/ndim)-quantile at the n*frac convention; else textbook median
-        if legacy:
-            mad[k] = _interp(ad, cnt, mad_frac, True)
-        else:
-            mad[k] = _interp(ad, cnt, 0.5, False)
+        mad[k] = _interp(ad, cnt, mad_frac if legacy else 0.5, legacy)
     return lq, med, uq, mad

--- a/src/cp_measure/primitives/_segment_numba.py
+++ b/src/cp_measure/primitives/_segment_numba.py
@@ -168,13 +168,15 @@ def segment_resid_sumsq(values, seg0, n, mean):
 
 
 @njit(cache=True)
-def _interp(sorted_seg, n, frac):
-    """Linear interpolation at position ``n * frac`` within a sorted segment.
+def _interp(sorted_seg, n, frac, legacy):
+    """Linear interpolation within a sorted segment at the chosen convention.
 
-    Matches the reference's ``cumsum(areas)``-offset interpolation: the local
-    position is ``count * frac``; clamp the upper neighbour at the last element.
+    ``legacy`` selects the local position: ``n * frac`` (the CellProfiler /
+    ``cumsum(areas)``-offset convention) when True, else ``(n - 1) * frac``
+    (``numpy.percentile`` 'linear'/type-7). The upper neighbour is clamped at the
+    last element.
     """
-    pos = n * frac
+    pos = n * frac if legacy else (n - 1) * frac
     lo = int(pos)
     if lo > n - 1:
         lo = n - 1
@@ -186,12 +188,14 @@ def _interp(sorted_seg, n, frac):
 
 
 @njit(cache=True)
-def segment_quantiles(values, seg0, counts, n, mad_frac):
+def segment_quantiles(values, seg0, counts, n, mad_frac, legacy):
     """Per-segment quartiles/median + MAD via scatter-into-segments + sort.
 
     Builds CSR offsets from ``counts``, scatters values into one flat buffer,
-    sorts each segment slice in place, and interpolates. MAD reuses the sorted
-    absolute deviations from the median at ``mad_frac`` (= 1 / original ndim).
+    sorts each segment slice in place, and interpolates. ``legacy`` selects the
+    interpolation convention (see :func:`_interp`). MAD reuses the sorted absolute
+    deviations from the median: in legacy mode the ``mad_frac`` (= 1 / original
+    ndim) quantile; otherwise the plain median (the textbook MAD).
     """
     starts = np.zeros(n, np.int64)
     acc = 0
@@ -219,10 +223,14 @@ def segment_quantiles(values, seg0, counts, n, mad_frac):
         s = starts[k]
         seg = buf[s : s + cnt]
         seg.sort()
-        lq[k] = _interp(seg, cnt, 0.25)
-        med[k] = _interp(seg, cnt, 0.5)
-        uq[k] = _interp(seg, cnt, 0.75)
+        lq[k] = _interp(seg, cnt, 0.25, legacy)
+        med[k] = _interp(seg, cnt, 0.5, legacy)
+        uq[k] = _interp(seg, cnt, 0.75, legacy)
         ad = np.abs(seg - med[k])
         ad.sort()
-        mad[k] = _interp(ad, cnt, mad_frac)
+        # legacy: (1/ndim)-quantile at the n*frac convention; else textbook median
+        if legacy:
+            mad[k] = _interp(ad, cnt, mad_frac, True)
+        else:
+            mad[k] = _interp(ad, cnt, 0.5, False)
     return lq, med, uq, mad

--- a/test/test_backend_correctness.py
+++ b/test/test_backend_correctness.py
@@ -79,6 +79,18 @@ def test_intensity_quartile_conventions_anchor():
     assert old["Intensity_UpperQuartileIntensity"][0] == pytest.approx(3.0)
 
 
+def test_get_core_measurements_threads_legacy():
+    """bulk.get_core_measurements(legacy=...) binds the convention into intensity."""
+    from cp_measure.bulk import get_core_measurements
+
+    mask = np.ones((1, 4), dtype=np.int32)
+    pixels = np.array([[0.0, 1.0, 2.0, 3.0]])
+    new = get_core_measurements(legacy=False)["intensity"](mask, pixels)
+    old = get_core_measurements(legacy=True)["intensity"](mask, pixels)
+    assert new["Intensity_LowerQuartileIntensity"][0] == pytest.approx(0.75)
+    assert old["Intensity_LowerQuartileIntensity"][0] == pytest.approx(1.0)
+
+
 @requires_numba
 def test_set_accelerator_numba_composes_with_numpy():
     cp_measure.set_accelerator("numba")

--- a/test/test_backend_correctness.py
+++ b/test/test_backend_correctness.py
@@ -50,15 +50,33 @@ def _assert_dicts_match(ref, got):
 
 
 @requires_numba
+@pytest.mark.parametrize("legacy", [False, True], ids=["new", "legacy"])
 @pytest.mark.parametrize("edge", [True, False], ids=["edge", "noedge"])
 @pytest.mark.parametrize("dim", ["2d", "3d"])
-def test_numba_intensity_matches_numpy(dim, edge):
+def test_numba_intensity_matches_numpy(dim, edge, legacy):
     from cp_measure.core.numba import get_intensity as intensity_numba
 
     mask, pixels = _mask_pixels_2d() if dim == "2d" else _mask_pixels_3d()
-    ref = intensity_numpy(mask, pixels, edge_measurements=edge)
-    got = intensity_numba(mask, pixels, edge_measurements=edge)
+    ref = intensity_numpy(mask, pixels, edge_measurements=edge, legacy=legacy)
+    got = intensity_numba(mask, pixels, edge_measurements=edge, legacy=legacy)
     _assert_dicts_match(ref, got)
+
+
+def test_intensity_quartile_conventions_anchor():
+    """Pin both conventions to hand-checked values on one object with pixels
+    [0, 1, 2, 3]: new == numpy.percentile ((n-1)*q); legacy == CellProfiler n*q."""
+    mask = np.ones((1, 4), dtype=np.int32)
+    pixels = np.array([[0.0, 1.0, 2.0, 3.0]])
+    new = intensity_numpy(mask, pixels, edge_measurements=False, legacy=False)
+    old = intensity_numpy(mask, pixels, edge_measurements=False, legacy=True)
+    # new: numpy.percentile([0,1,2,3], [25,50,75]) = 0.75 / 1.5 / 2.25
+    assert new["Intensity_LowerQuartileIntensity"][0] == pytest.approx(0.75)
+    assert new["Intensity_MedianIntensity"][0] == pytest.approx(1.5)
+    assert new["Intensity_UpperQuartileIntensity"][0] == pytest.approx(2.25)
+    # legacy n*q: positions 1.0 / 2.0 / 3.0 -> sorted[1] / sorted[2] / sorted[3]
+    assert old["Intensity_LowerQuartileIntensity"][0] == pytest.approx(1.0)
+    assert old["Intensity_MedianIntensity"][0] == pytest.approx(2.0)
+    assert old["Intensity_UpperQuartileIntensity"][0] == pytest.approx(3.0)
 
 
 @requires_numba

--- a/test/test_featurizer.py
+++ b/test/test_featurizer.py
@@ -44,6 +44,18 @@ class TestSmoke:
         _, _, rows = featurize(image_2d_1ch, mask_2d, config, image_id="plate1_A01")
         assert all(r[0] == "plate1_A01" for r in rows)
 
+    def test_legacy_flag_changes_intensity_quartiles(self, image_2d_1ch, mask_2d):
+        base = {**ALL_OFF, "intensity": True}
+        d_new, cols, _ = featurize(
+            image_2d_1ch, mask_2d, make_featurizer_config(["DNA"], legacy=False, **base)
+        )
+        d_old, _, _ = featurize(
+            image_2d_1ch, mask_2d, make_featurizer_config(["DNA"], legacy=True, **base)
+        )
+        qcols = [i for i, c in enumerate(cols) if "LowerQuartileIntensity" in c]
+        assert qcols, "no quartile column produced"
+        assert not np.allclose(d_new[:, qcols], d_old[:, qcols])
+
     def test_values_finite_and_nontrivial(self, image_2d_2ch, mask_2d):
         with pytest.warns(UserWarning, match="No channel names"):
             data, columns, _ = featurize(image_2d_2ch, mask_2d)


### PR DESCRIPTION
Introduces a single `legacy: bool = False` to both `get_intensity` backends, gating the four quantile features (`LowerQuartile` / `Median` / `UpperQuartile` / `MAD`).

## Behaviour
| `legacy` | quartiles / median | MAD |
|---|---|---|
| `False` (new default) | `numpy.percentile` 'linear' — `(n-1)·q` | textbook `median(\|x − median\|)` |
| `True` | original CellProfiler `n·q` | `(1/ndim)`-quantile of `\|x − median\|` |

`legacy=True` reproduces today's `main` output **byte-for-byte**. All other intensity features are unchanged.

## Implementation
- **numpy**: parameterizes the existing `cumsum`-offset interpolation block with one `span = areas if legacy else (areas - 1)` (+ matching MAD fraction). No new code path, no perf change.
- **numba**: `_interp(..., legacy)` selects `n·q` vs `(n-1)·q`; `segment_quantiles` threads it.
- The two backends agree for **both** flag values by construction — `test_numba_intensity_matches_numpy` is parametrized over `legacy ∈ {False, True}`, plus a value anchor on `[0,1,2,3]`.

## Notes
- **Default-output change** for the 4 quantile features (esp. 3D MAD: true median vs `1/3`-quantile). Set `legacy=True` for CellProfiler-exact values.