### PR TITLE
perf(utils): rewrite masks_to_ijv as one nonzero + stable argsort

### DIFF
--- a/src/cp_measure/utils.py
+++ b/src/cp_measure/utils.py
@@ -31,22 +31,13 @@ def get_test_pixels_mask():
 
 def masks_to_ijv(masks: numpy.ndarray) -> numpy.ndarray:
     """
-    input: 2d boolean array
-    output: (n, 3) integer array following (i,j,1)
+    input: 2d integer label array
+    output: (n, 3) integer array of rows (i, j, label) sorted by label
     """
-
-    # Extract coordinates of object from boolean mask
-    masks_ijv = numpy.empty((0, 3), dtype=int)
-    for label in range(masks.max()):
-        i, j = numpy.where(masks == label + 1)
-        n = len(i)
-        ijv = numpy.empty((n, 3), dtype=int)
-        ijv[:, 0] = i
-        ijv[:, 1] = j
-        ijv[:, 2] = label + 1
-        masks_ijv = numpy.concatenate((masks_ijv, ijv))
-
-    return masks_ijv
+    i, j = numpy.nonzero(masks)
+    v = masks[i, j]
+    order = numpy.argsort(v, kind="stable")
+    return numpy.column_stack((i[order], j[order], v[order])).astype(int, copy=False)
 
 
 def labels_to_binmasks(masks: numpy.ndarray) -> numpy.ndarray:


### PR DESCRIPTION
Drops the O(L * pixels) per-label loop for a single `numpy.nonzero` + stable argsort by label value. Outputs identical in content; within-label ordering preserved by the stable sort.

Touches a single file: `src/cp_measure/utils.py` (+6 / −15).