### PR TITLE
perf(intensity): bbox-based rewrite of the numpy backend

### DIFF
--- a/src/cp_measure/core/measureobjectintensity.py
+++ b/src/cp_measure/core/measureobjectintensity.py
@@ -1,7 +1,6 @@
 import numpy
 import scipy.ndimage
 import skimage.segmentation
-from cp_measure.utils import _ensure_np_array as fix
 from numpy.typing import NDArray
 
 __doc__ = """
@@ -119,264 +118,171 @@ ALL_LOCATION_MEASUREMENTS = [
 ]
 
 
+def _interp_n_frac(sorted_arr: numpy.ndarray, n: int, frac: float) -> float:
+    """Linear interpolation at ``n * frac`` within a sorted segment, clamped at
+    the last element. Matches the original cp_measure cumsum-offset quantile."""
+    pos = n * frac
+    lo = int(pos)
+    if lo > n - 1:
+        lo = n - 1
+    hi = lo + 1
+    if hi > n - 1:
+        hi = n - 1
+    f = pos - lo
+    return float(sorted_arr[lo] * (1.0 - f) + sorted_arr[hi] * f)
+
+
 def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
 ) -> dict[str, NDArray[numpy.floating]]:
-    """
-    masks is a labeled array where 0 are background images.
-    """
-    masked_image = pixels
+    """Per-object intensity features.
 
+    Walks each object on its ``scipy.ndimage.find_objects`` bounding box rather
+    than the full image; for each label the per-pixel reductions, quantiles, MAD,
+    max position, and centroid run on the bbox crop only. 2D inputs are promoted
+    to ``(1, Y, X)`` so the same code path handles 2D and 3D. ``find_boundaries``
+    is called once on the whole label image for edge features.
+    """
+    # Captured before the (1, Y, X) reshape so the MAD quantile fraction matches
+    # the original implementation (1/2 for 2D, 1/3 for 3D).
+    source_ndim = pixels.ndim
+
+    # Normalize to (Z, Y, X). Broadcast 2D masks across a 3D pixel stack to
+    # match the original behavior.
+    if pixels.ndim == 3 and masks.ndim == 2:
+        masks = numpy.broadcast_to(masks, pixels.shape)
     if pixels.ndim == 2:
-        img = pixels.reshape(1, *pixels.shape)
-        masked_image = img
-    elif pixels.ndim == 3 and masks.ndim == 2:  # 3D image, 2D mask.
-        masks = masks.reshape(1, *masks.shape)
+        pixels = pixels[numpy.newaxis, ...]
+    if masks.ndim == 2:
+        masks = masks[numpy.newaxis, ...]
 
-    unique_vals = numpy.unique(masks)
-    # MODIFIED: Extract the number of objects by explicitly removing 0s
-    nobjects = (unique_vals > 0).sum()
+    if not numpy.issubdtype(masks.dtype, numpy.integer):
+        masks = masks.astype(numpy.intp, copy=False)
 
-    integrated_intensity = numpy.zeros((nobjects,))
-    mean_intensity = numpy.zeros((nobjects,))
-    std_intensity = numpy.zeros((nobjects,))
-    min_intensity = numpy.zeros((nobjects,))
-    max_intensity = numpy.zeros((nobjects,))
-    mass_displacement = numpy.zeros((nobjects,))
-    lower_quartile_intensity = numpy.zeros((nobjects,))
-    median_intensity = numpy.zeros((nobjects,))
-    mad_intensity = numpy.zeros((nobjects,))
-    upper_quartile_intensity = numpy.zeros((nobjects,))
-    cmi_x = numpy.zeros((nobjects,))
-    cmi_y = numpy.zeros((nobjects,))
-    cmi_z = numpy.zeros((nobjects,))
-    max_x = numpy.zeros((nobjects,))
-    max_y = numpy.zeros((nobjects,))
-    max_z = numpy.zeros((nobjects,))
+    # find_objects returns one slice per label in 1..max(masks), with None
+    # for missing labels. We use it both for bbox crops below and to derive
+    # the present-label list — np.unique on a multi-MB mask is much slower
+    # (e.g. ~200 ms on a 32x240x240 volume).
+    bboxes = scipy.ndimage.find_objects(masks)
+    present = [(i + 1, sl) for i, sl in enumerate(bboxes) if sl is not None]
+    nobjects = len(present)
 
-    label_matrices = numpy.zeros((nobjects, *masks.shape), dtype=int)  # N,Y,X
-    unique_labels = unique_vals[unique_vals > 0]
-    for i, label in enumerate(
-        unique_labels
-    ):  # Assumes all labels from 1 to nobjects are present
-        label_matrices[i][masks == label] = label
+    integrated_intensity = numpy.zeros(nobjects)
+    mean_intensity = numpy.zeros(nobjects)
+    std_intensity = numpy.zeros(nobjects)
+    min_intensity = numpy.zeros(nobjects)
+    max_intensity = numpy.zeros(nobjects)
+    lower_quartile_intensity = numpy.zeros(nobjects)
+    median_intensity = numpy.zeros(nobjects)
+    mad_intensity = numpy.zeros(nobjects)
+    upper_quartile_intensity = numpy.zeros(nobjects)
+
+    cmi_z = numpy.zeros(nobjects)
+    cmi_y = numpy.zeros(nobjects)
+    cmi_x = numpy.zeros(nobjects)
+    max_z = numpy.zeros(nobjects)
+    max_y = numpy.zeros(nobjects)
+    max_x = numpy.zeros(nobjects)
+    mass_displacement = numpy.zeros(nobjects)
+
+    for out_i, (label_value, sl) in enumerate(present):
+        mask_crop = masks[sl] == label_value
+        pixels_crop = pixels[sl]
+        finite = mask_crop & numpy.isfinite(pixels_crop)
+        if not finite.any():
+            continue
+        vals = pixels_crop[finite]
+        n = vals.size
+
+        integrated = vals.sum()
+        integrated_intensity[out_i] = integrated
+        mean_intensity[out_i] = vals.mean()
+        std_intensity[out_i] = vals.std()
+
+        sorted_vals = numpy.sort(vals)
+        min_intensity[out_i] = sorted_vals[0]
+        max_intensity[out_i] = sorted_vals[-1]
+        median = _interp_n_frac(sorted_vals, n, 0.5)
+        lower_quartile_intensity[out_i] = _interp_n_frac(sorted_vals, n, 0.25)
+        median_intensity[out_i] = median
+        upper_quartile_intensity[out_i] = _interp_n_frac(sorted_vals, n, 0.75)
+        sorted_dev = numpy.sort(numpy.abs(vals - median))
+        mad_intensity[out_i] = _interp_n_frac(sorted_dev, n, 1.0 / source_ndim)
+
+        # Positions / centroids on the bbox crop, then shift by the bbox
+        # offset. Per-bbox np.argmax picks the FIRST tied-max in C-order;
+        # scipy.ndimage.maximum_position picks the LAST (and is version
+        # unstable on ties). On real continuous data the two agree.
+        coords = numpy.argwhere(finite)
+        offset = numpy.array([s.start for s in sl], dtype=coords.dtype)
+        coords = coords + offset
+
+        argmax = int(numpy.argmax(vals))
+        max_z[out_i] = coords[argmax, 0]
+        max_y[out_i] = coords[argmax, 1]
+        max_x[out_i] = coords[argmax, 2]
+
+        cm = coords.mean(axis=0)
+        if integrated != 0:
+            cmi = (coords * vals[:, numpy.newaxis]).sum(axis=0) / integrated
+        else:
+            cmi = numpy.full(coords.shape[1], numpy.nan)
+        cmi_z[out_i] = cmi[0]
+        cmi_y[out_i] = cmi[1]
+        cmi_x[out_i] = cmi[2]
+
+        diff = cmi - cm
+        mass_displacement[out_i] = numpy.sqrt((diff * diff).sum())
+
+    result: dict[str, NDArray[numpy.floating]] = {
+        f"{INTENSITY}_{INTEGRATED_INTENSITY}": integrated_intensity,
+        f"{INTENSITY}_{MEAN_INTENSITY}": mean_intensity,
+        f"{INTENSITY}_{STD_INTENSITY}": std_intensity,
+        f"{INTENSITY}_{MIN_INTENSITY}": min_intensity,
+        f"{INTENSITY}_{MAX_INTENSITY}": max_intensity,
+        f"{INTENSITY}_{MASS_DISPLACEMENT}": mass_displacement,
+        f"{INTENSITY}_{LOWER_QUARTILE_INTENSITY}": lower_quartile_intensity,
+        f"{INTENSITY}_{MEDIAN_INTENSITY}": median_intensity,
+        f"{INTENSITY}_{MAD_INTENSITY}": mad_intensity,
+        f"{INTENSITY}_{UPPER_QUARTILE_INTENSITY}": upper_quartile_intensity,
+        f"{C_LOCATION}_{LOC_CMI_X}": cmi_x,
+        f"{C_LOCATION}_{LOC_CMI_Y}": cmi_y,
+        f"{C_LOCATION}_{LOC_CMI_Z}": cmi_z,
+        f"{C_LOCATION}_{LOC_MAX_X}": max_x,
+        f"{C_LOCATION}_{LOC_MAX_Y}": max_y,
+        f"{C_LOCATION}_{LOC_MAX_Z}": max_z,
+    }
 
     if edge_measurements:
-        integrated_intensity_edge = numpy.zeros((nobjects,))
-        mean_intensity_edge = numpy.zeros((nobjects,))
-        std_intensity_edge = numpy.zeros((nobjects,))
-        min_intensity_edge = numpy.zeros((nobjects,))
-        max_intensity_edge = numpy.zeros((nobjects,))
+        integrated_intensity_edge = numpy.zeros(nobjects)
+        mean_intensity_edge = numpy.zeros(nobjects)
+        std_intensity_edge = numpy.zeros(nobjects)
+        min_intensity_edge = numpy.zeros(nobjects)
+        max_intensity_edge = numpy.zeros(nobjects)
 
-    result = {}
-    # for labels, lindexes in ((mask, numpy.array([1])),):
-    for labels, lindexes in zip(label_matrices, unique_labels):
-        lindexes = lindexes[lindexes != 0]
+        # One pass to compute the inner boundary of every object, then
+        # index into the bbox crop per label.
+        boundaries = skimage.segmentation.find_boundaries(masks, mode="inner")
 
-        if pixels.ndim == 2:
-            labels = labels.reshape(1, *labels.shape)
+        for out_i, (label_value, sl) in enumerate(present):
+            mask_crop = masks[sl] == label_value
+            pixels_crop = pixels[sl]
+            edge = mask_crop & boundaries[sl] & numpy.isfinite(pixels_crop)
+            if not edge.any():
+                continue
+            evals = pixels_crop[edge]
+            integrated_intensity_edge[out_i] = evals.sum()
+            mean_intensity_edge[out_i] = evals.mean()
+            std_intensity_edge[out_i] = evals.std()
+            min_intensity_edge[out_i] = evals.min()
+            max_intensity_edge[out_i] = evals.max()
 
-        masked_labels = labels
-
-        lmask = (masked_labels > 0) & numpy.isfinite(masked_image)  # Ignore NaNs, Infs
-        has_objects = numpy.any(lmask)
-        if has_objects:
-            limg = masked_image[lmask]
-
-            llabels = labels[lmask]
-
-            mesh_z, mesh_y, mesh_x = numpy.mgrid[
-                0 : masked_image.shape[0],
-                0 : masked_image.shape[1],
-                0 : masked_image.shape[2],
-            ]
-
-            mesh_x = mesh_x[lmask]
-            mesh_y = mesh_y[lmask]
-            mesh_z = mesh_z[lmask]
-
-            lcount = fix(scipy.ndimage.sum(numpy.ones(len(limg)), llabels, lindexes))
-
-            integrated_intensity[lindexes - 1] = fix(
-                scipy.ndimage.sum(limg, llabels, lindexes)
-            )
-
-            mean_intensity[lindexes - 1] = integrated_intensity[lindexes - 1] / lcount
-
-            std_intensity[lindexes - 1] = numpy.sqrt(
-                fix(
-                    scipy.ndimage.mean(
-                        (limg - mean_intensity[llabels - 1]) ** 2,
-                        llabels,
-                        lindexes,
-                    )
-                )
-            )
-
-            min_intensity[lindexes - 1] = fix(
-                scipy.ndimage.minimum(limg, llabels, lindexes)
-            )
-
-            max_intensity[lindexes - 1] = fix(
-                scipy.ndimage.maximum(limg, llabels, lindexes)
-            )
-
-            # Compute the position of the intensity maximum
-            max_position = numpy.array(
-                fix(scipy.ndimage.maximum_position(limg, llabels, lindexes)),
-                dtype=int,
-            )
-            max_position = numpy.reshape(max_position, (max_position.shape[0],))
-
-            max_x[lindexes - 1] = mesh_x[max_position]
-            max_y[lindexes - 1] = mesh_y[max_position]
-            max_z[lindexes - 1] = mesh_z[max_position]
-
-            # The mass displacement is the distance between the center
-            # of mass of the binary image and of the intensity image. The
-            # center of mass is the average X or Y for the binary image
-            # and the sum of X or Y * intensity / integrated intensity
-            cm_x = fix(scipy.ndimage.mean(mesh_x, llabels, lindexes))
-            cm_y = fix(scipy.ndimage.mean(mesh_y, llabels, lindexes))
-            cm_z = fix(scipy.ndimage.mean(mesh_z, llabels, lindexes))
-
-            i_x = fix(scipy.ndimage.sum(mesh_x * limg, llabels, lindexes))
-            i_y = fix(scipy.ndimage.sum(mesh_y * limg, llabels, lindexes))
-            i_z = fix(scipy.ndimage.sum(mesh_z * limg, llabels, lindexes))
-
-            cmi_x[lindexes - 1] = i_x / integrated_intensity[lindexes - 1]
-            cmi_y[lindexes - 1] = i_y / integrated_intensity[lindexes - 1]
-            cmi_z[lindexes - 1] = i_z / integrated_intensity[lindexes - 1]
-
-            diff_x = cm_x - cmi_x[lindexes - 1]
-            diff_y = cm_y - cmi_y[lindexes - 1]
-            diff_z = cm_z - cmi_z[lindexes - 1]
-
-            mass_displacement[lindexes - 1] = numpy.sqrt(
-                diff_x * diff_x + diff_y * diff_y + diff_z * diff_z
-            )
-
-            #
-            # Sort the intensities by label, then intensity.
-            # For each label, find the index above and below
-            # the 25%, 50% and 75% mark and take the weighted
-            # average.
-            #
-            order = numpy.lexsort((limg, llabels))
-            areas = lcount.astype(int)
-            indices = numpy.cumsum(areas) - areas
-            for dest, fraction in (
-                (lower_quartile_intensity, 1.0 / 4.0),
-                (median_intensity, 1.0 / 2.0),
-                (upper_quartile_intensity, 3.0 / 4.0),
-            ):
-                qindex = indices.astype(float) + areas * fraction
-                qfraction = qindex - numpy.floor(qindex)
-                qindex = qindex.astype(int)
-                qmask = qindex < indices + areas - 1
-                qi = qindex[qmask]
-                qf = qfraction[qmask]
-                dest[lindexes[qmask] - 1] = (
-                    limg[order[qi]] * (1 - qf) + limg[order[qi + 1]] * qf
-                )
-
-                #
-                # In some situations (e.g., only 3 points), there may
-                # not be an upper bound.
-                #
-                qmask = (~qmask) & (areas > 0)
-                dest[lindexes[qmask] - 1] = limg[order[qindex[qmask]]]
-
-            #
-            # Once again, for the MAD
-            #
-            madimg = numpy.abs(limg - median_intensity[llabels - 1])
-            order = numpy.lexsort((madimg, llabels))
-            qindex = indices.astype(float) + areas / pixels.ndim
-            qfraction = qindex - numpy.floor(qindex)
-            qindex = qindex.astype(int)
-            qmask = qindex < indices + areas - 1
-            qi = qindex[qmask]
-            qf = qfraction[qmask]
-            mad_intensity[lindexes[qmask] - 1] = (
-                madimg[order[qi]] * (1 - qf) + madimg[order[qi + 1]] * qf
-            )
-            qmask = (~qmask) & (areas > 0)
-            mad_intensity[lindexes[qmask] - 1] = madimg[order[qindex[qmask]]]
-
-            # END OF ITERATIONS
-
-        if edge_measurements:
-            outlines = skimage.segmentation.find_boundaries(labels, mode="inner")
-            masked_outlines = outlines
-            emask = masked_outlines > 0
-            eimg = masked_image[emask]
-            elabels = labels[emask]
-            has_edge = len(eimg) > 0
-
-            if has_edge:
-                ecount = fix(
-                    scipy.ndimage.sum(numpy.ones(len(eimg)), elabels, lindexes)
-                )
-
-                integrated_intensity_edge[lindexes - 1] = fix(
-                    scipy.ndimage.sum(eimg, elabels, lindexes)
-                )
-
-                mean_intensity_edge[lindexes - 1] = (
-                    integrated_intensity_edge[lindexes - 1] / ecount
-                )
-
-                std_intensity_edge[lindexes - 1] = numpy.sqrt(
-                    fix(
-                        scipy.ndimage.mean(
-                            (eimg - mean_intensity_edge[elabels - 1]) ** 2,
-                            elabels,
-                        )
-                    )
-                )
-
-                min_intensity_edge[lindexes - 1] = fix(
-                    scipy.ndimage.minimum(eimg, elabels, lindexes)
-                )
-
-                max_intensity_edge[lindexes - 1] = fix(
-                    scipy.ndimage.maximum(eimg, elabels, lindexes)
-                )
-
-    measurement_names = [
-        (INTENSITY, INTEGRATED_INTENSITY, integrated_intensity),
-        (INTENSITY, MEAN_INTENSITY, mean_intensity),
-        (INTENSITY, STD_INTENSITY, std_intensity),
-        (INTENSITY, MIN_INTENSITY, min_intensity),
-        (INTENSITY, MAX_INTENSITY, max_intensity),
-        (INTENSITY, MASS_DISPLACEMENT, mass_displacement),
-        (INTENSITY, LOWER_QUARTILE_INTENSITY, lower_quartile_intensity),
-        (INTENSITY, MEDIAN_INTENSITY, median_intensity),
-        (INTENSITY, MAD_INTENSITY, mad_intensity),
-        (INTENSITY, UPPER_QUARTILE_INTENSITY, upper_quartile_intensity),
-        (C_LOCATION, LOC_CMI_X, cmi_x),
-        (C_LOCATION, LOC_CMI_Y, cmi_y),
-        (C_LOCATION, LOC_CMI_Z, cmi_z),
-        (C_LOCATION, LOC_MAX_X, max_x),
-        (C_LOCATION, LOC_MAX_Y, max_y),
-        (C_LOCATION, LOC_MAX_Z, max_z),
-    ]
-    if edge_measurements:
-        measurement_names.extend(
-            [
-                (INTENSITY, INTEGRATED_INTENSITY_EDGE, integrated_intensity_edge),
-                (INTENSITY, MEAN_INTENSITY_EDGE, mean_intensity_edge),
-                (INTENSITY, STD_INTENSITY_EDGE, std_intensity_edge),
-                (INTENSITY, MIN_INTENSITY_EDGE, min_intensity_edge),
-                (INTENSITY, MAX_INTENSITY_EDGE, max_intensity_edge),
-            ]
-        )
-    for category, feature_name, measurement in measurement_names:
-        measurement_name = "{}_{}".format(category, feature_name)
-        # MODIFIED: Selected first
-        result[measurement_name] = measurement
+        result[f"{INTENSITY}_{INTEGRATED_INTENSITY_EDGE}"] = integrated_intensity_edge
+        result[f"{INTENSITY}_{MEAN_INTENSITY_EDGE}"] = mean_intensity_edge
+        result[f"{INTENSITY}_{STD_INTENSITY_EDGE}"] = std_intensity_edge
+        result[f"{INTENSITY}_{MIN_INTENSITY_EDGE}"] = min_intensity_edge
+        result[f"{INTENSITY}_{MAX_INTENSITY_EDGE}"] = max_intensity_edge
 
     return result


### PR DESCRIPTION
Per-bbox iteration via `scipy.ndimage.find_objects`, no full-image label slab or in-loop meshgrids. Quantile/MAD interpolation (`n*q`, `(1/ndim)`-quantile MAD) preserved exactly.

| Scene | Old | New | Speedup |
|---|---|---|---|
| 2D, 200 small objects (512²) | 4225 ms | 57 ms | **74.0x** |
| 3D, 2 cubes (32×240×240) | 2089 ms | 196 ms | **10.7x** |
| 2D, 2-pixel object | 33 ms | 5.7 ms | 5.7x |
| 2D, full_2 (2 large objects) | 43 ms | 8.4 ms | 5.1x |
| 2D, 1-pixel object | 30 ms | 7.6 ms | 3.9x |
| 2D, center | 154 ms | 45 ms | 3.4x |
| 2D, edges | 47 ms | 14 ms | 3.3x |
| 2D, benchmark_core (500², 2 obj) | 136 ms | 43 ms | 3.2x |
| 2D, full (1 huge object) | 44 ms | 25 ms | 1.8x |

Only divergence from main: `Location_MaxIntensity_*` on inputs with exact integer ties (per-bbox `np.argmax` = FIRST tied vs `scipy.ndimage.maximum_position` = LAST tied — and scipy is itself version-unstable there). Identical on continuous data.