### PR TITLE
feat(intensity): add `legacy` flag for percentile/MAD convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,10 @@ measurecolocalization.get_correlation_overlap
 ### Important notes
 
 - **Contiguous labels**: The input labels must be sequential (e.g., `[1,2,3]`, not `[1,3,4]`). You can use `skimage.segmentation.relabel_sequential` to ensure compliance.
-- **Fidelity**: If you need to match CellProfiler measurements 1:1, you must convert your image arrays to float values between 0 and 1. For instance, if you have an array of data type uint16, you must divide them all by 65535. This is important for radial distribution measurements.
+- **Fidelity**: If you need to match CellProfiler measurements 1:1, you must convert your image arrays to float values between 0 and 1. For instance, if you have an array of data type uint16, you must divide them all by 65535. This is important for radial distribution measurements. For the four intensity quantile features (`LowerQuartileIntensity`, `MedianIntensity`, `UpperQuartileIntensity`, `MADIntensity`) you additionally need `legacy=True` — see below.
 - **Speed**: The Granularity measurement is particularly slow (~80% of the compute time). Skip this one it if speed is of utmost importance.
-
-### Known limitations
-
-- Some features produce a minor (1e-16) discrepancy when using one vs multiple mask in some features. The issue lies upstream ([centrosome](https://github.com/afermg/cp_measure/issues/18#issuecomment-4593709963), [scipy](https://github.com/scipy/scipy/issues/25279)), and does not significantly impact my use-cases.
+- **Legacy percentile convention**: `get_intensity` (numpy and numba backends), `get_core_measurements`, `get_core_measurements_3d`, and `make_featurizer_config` accept `legacy: bool = False`. The default uses `numpy.percentile` 'linear' (`(n-1)*q`) quartiles and the textbook `median(|x - median(x)|)` MAD. Pass `legacy=True` to reproduce the original cp_measure / CellProfiler behavior: `n*q` quartiles and the `(1/ndim)`-quantile MAD (which returns the 33rd percentile in 3D rather than the median). All other intensity features are identical either way.
+- **Minor floating-point discrepancy**: Some features produce a minor (1e-16) discrepancy when using one vs multiple mask in some features. The issue lies upstream ([centrosome](https://github.com/afermg/cp_measure/issues/18#issuecomment-4593709963), [scipy](https://github.com/scipy/scipy/issues/25279)), and does not significantly impact my use-cases.
 
 ## Similar projects
 

--- a/src/cp_measure/bulk.py
+++ b/src/cp_measure/bulk.py
@@ -3,6 +3,7 @@ Wrapper to fetch measurement functions in bulk. We are keeping the ugly filename
 match the original names. This may change in the future.
 """
 
+from functools import partial
 from typing import Callable
 
 from cp_measure.core import (
@@ -88,14 +89,37 @@ def _dispatch(name: str) -> dict[str, Callable]:
     )
 
 
-def get_core_measurements() -> dict[str, Callable]:
-    return _dispatch("core")
+# Features whose result honours the ``legacy`` percentile convention (see
+# cp_measure.core.measureobjectintensity.get_intensity). Extend as more
+# features gain a legacy/new split.
+_LEGACY_FEATURES = ("intensity",)
 
 
-def get_core_measurements_3d() -> dict[str, Callable]:
-    """Return only measurements that support 3D input."""
-    core = _dispatch("core")
-    return {k: core[k] for k in _3D_FEATURES}
+def _apply_legacy(core: dict[str, Callable], legacy: bool) -> dict[str, Callable]:
+    """Bind ``legacy=True`` into the features that honour it; no-op when False."""
+    if not legacy:
+        return core
+    return {
+        name: (partial(fn, legacy=True) if name in _LEGACY_FEATURES else fn)
+        for name, fn in core.items()
+    }
+
+
+def get_core_measurements(legacy: bool = False) -> dict[str, Callable]:
+    """Core per-object measurement functions.
+
+    ``legacy`` (default False) selects the original CellProfiler ``n*q`` percentile
+    convention for the intensity quartile/MAD features instead of the default
+    ``numpy.percentile`` ``(n-1)*q``; see
+    :func:`cp_measure.core.measureobjectintensity.get_intensity`.
+    """
+    return _apply_legacy(_dispatch("core"), legacy)
+
+
+def get_core_measurements_3d(legacy: bool = False) -> dict[str, Callable]:
+    """Return only measurements that support 3D input (see ``legacy`` above)."""
+    core = {k: _dispatch("core")[k] for k in _3D_FEATURES}
+    return _apply_legacy(core, legacy)
 
 
 def get_correlation_measurements() -> dict[str, Callable]:

--- a/src/cp_measure/core/measureobjectintensity.py
+++ b/src/cp_measure/core/measureobjectintensity.py
@@ -118,10 +118,14 @@ ALL_LOCATION_MEASUREMENTS = [
 ]
 
 
-def _interp_n_frac(sorted_arr: numpy.ndarray, n: int, frac: float) -> float:
-    """Linear interpolation at ``n * frac`` within a sorted segment, clamped at
-    the last element. Matches the original cp_measure cumsum-offset quantile."""
-    pos = n * frac
+def _interp(sorted_arr: numpy.ndarray, n: int, frac: float, legacy: bool) -> float:
+    """Linear interpolation within a sorted segment at the chosen convention.
+
+    ``legacy=True`` uses ``pos = n * frac`` (CellProfiler / cumsum-offset);
+    ``legacy=False`` uses ``pos = (n - 1) * frac`` (``numpy.percentile`` 'linear').
+    The upper neighbour is clamped at the last element either way.
+    """
+    pos = n * frac if legacy else (n - 1) * frac
     lo = int(pos)
     if lo > n - 1:
         lo = n - 1
@@ -136,6 +140,7 @@ def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
+    legacy: bool = False,
 ) -> dict[str, NDArray[numpy.floating]]:
     """Per-object intensity features.
 
@@ -144,6 +149,16 @@ def get_intensity(
     max position, and centroid run on the bbox crop only. 2D inputs are promoted
     to ``(1, Y, X)`` so the same code path handles 2D and 3D. ``find_boundaries``
     is called once on the whole label image for edge features.
+
+    Parameters
+    ----------
+    legacy
+        Selects the percentile convention for the four quantile features (Q1,
+        median, Q3, MAD). When False (default) quartiles use ``numpy.percentile``
+        'linear' ``(n-1)*q`` and MAD is the textbook ``median(|x - median(x)|)``.
+        When True, reproduce the original cp_measure / CellProfiler behavior:
+        quartiles at ``n*q`` and MAD as the ``(1/ndim)``-quantile of
+        ``|x - median(x)|``. All other features are unaffected.
     """
     # Captured before the (1, Y, X) reshape so the MAD quantile fraction matches
     # the original implementation (1/2 for 2D, 1/3 for 3D).
@@ -204,12 +219,15 @@ def get_intensity(
         sorted_vals = numpy.sort(vals)
         min_intensity[out_i] = sorted_vals[0]
         max_intensity[out_i] = sorted_vals[-1]
-        median = _interp_n_frac(sorted_vals, n, 0.5)
-        lower_quartile_intensity[out_i] = _interp_n_frac(sorted_vals, n, 0.25)
+        median = _interp(sorted_vals, n, 0.5, legacy)
+        lower_quartile_intensity[out_i] = _interp(sorted_vals, n, 0.25, legacy)
         median_intensity[out_i] = median
-        upper_quartile_intensity[out_i] = _interp_n_frac(sorted_vals, n, 0.75)
+        upper_quartile_intensity[out_i] = _interp(sorted_vals, n, 0.75, legacy)
         sorted_dev = numpy.sort(numpy.abs(vals - median))
-        mad_intensity[out_i] = _interp_n_frac(sorted_dev, n, 1.0 / source_ndim)
+        # MAD: legacy uses (1/ndim)-quantile of |x - median|; otherwise the
+        # textbook median.
+        mad_frac = (1.0 / source_ndim) if legacy else 0.5
+        mad_intensity[out_i] = _interp(sorted_dev, n, mad_frac, legacy)
 
         # Positions / centroids on the bbox crop, then shift by the bbox
         # offset. Per-bbox np.argmax picks the FIRST tied-max in C-order;

--- a/src/cp_measure/core/numba/measureobjectintensity.py
+++ b/src/cp_measure/core/numba/measureobjectintensity.py
@@ -54,8 +54,14 @@ def get_intensity(
     masks: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
     edge_measurements: bool = True,
+    legacy: bool = False,
 ) -> dict[str, NDArray[numpy.floating]]:
-    """masks is a labeled array where 0 are background."""
+    """masks is a labeled array where 0 are background.
+
+    ``legacy`` mirrors the numpy backend: False (default) uses ``numpy.percentile``
+    'linear' quartiles + textbook median MAD; True reproduces the original
+    CellProfiler ``n*q`` quartiles + ``(1/ndim)``-quantile MAD.
+    """
     orig_ndim = pixels.ndim
 
     masked_image = pixels
@@ -132,7 +138,7 @@ def get_intensity(
             median_intensity,
             upper_quartile_intensity,
             mad_intensity,
-        ) = segment_quantiles(values, seg0, count, nobjects, 1.0 / orig_ndim)
+        ) = segment_quantiles(values, seg0, count, nobjects, 1.0 / orig_ndim, legacy)
 
     if edge_measurements:
         integrated_intensity_edge = numpy.zeros(nobjects)

--- a/src/cp_measure/featurizer.py
+++ b/src/cp_measure/featurizer.py
@@ -28,6 +28,7 @@ def make_featurizer_config(
     channels: list[str] | None = None,
     *,
     objects: list[str] | None = None,
+    legacy: bool = False,
     intensity: bool = True,
     intensity_params: dict | None = None,
     texture: bool = True,
@@ -129,6 +130,7 @@ def make_featurizer_config(
     return {
         "channels": list(channels) if channels is not None else None,
         "objects": list(objects),
+        "legacy": legacy,
         "intensity": intensity,
         "intensity_params": intensity_params if intensity_params is not None else {},
         "texture": texture,
@@ -214,7 +216,12 @@ def featurize(
     )
 
     is_3d = image.ndim == 4
-    core_funcs = get_core_measurements_3d() if is_3d else get_core_measurements()
+    legacy = config.get("legacy", False)
+    core_funcs = (
+        get_core_measurements_3d(legacy=legacy)
+        if is_3d
+        else get_core_measurements(legacy=legacy)
+    )
     corr_funcs = get_correlation_measurements()
 
     if is_3d:

--- a/src/cp_measure/primitives/_segment_numba.py
+++ b/src/cp_measure/primitives/_segment_numba.py
@@ -168,13 +168,14 @@ def segment_resid_sumsq(values, seg0, n, mean):
 
 
 @njit(cache=True)
-def _interp(sorted_seg, n, frac):
-    """Linear interpolation at position ``n * frac`` within a sorted segment.
+def _interp(sorted_seg, n, frac, legacy):
+    """Linear interpolation within a sorted segment at the chosen convention.
 
-    Matches the reference's ``cumsum(areas)``-offset interpolation: the local
-    position is ``count * frac``; clamp the upper neighbour at the last element.
+    ``legacy=True`` uses ``pos = n * frac`` (the CellProfiler / cumsum-offset
+    convention); ``legacy=False`` uses ``pos = (n - 1) * frac``
+    (``numpy.percentile`` 'linear'). Upper neighbour clamped at the last element.
     """
-    pos = n * frac
+    pos = n * frac if legacy else (n - 1) * frac
     lo = int(pos)
     if lo > n - 1:
         lo = n - 1
@@ -186,12 +187,14 @@ def _interp(sorted_seg, n, frac):
 
 
 @njit(cache=True)
-def segment_quantiles(values, seg0, counts, n, mad_frac):
+def segment_quantiles(values, seg0, counts, n, mad_frac, legacy):
     """Per-segment quartiles/median + MAD via scatter-into-segments + sort.
 
     Builds CSR offsets from ``counts``, scatters values into one flat buffer,
-    sorts each segment slice in place, and interpolates. MAD reuses the sorted
-    absolute deviations from the median at ``mad_frac`` (= 1 / original ndim).
+    sorts each segment slice in place, and interpolates with the convention
+    selected by ``legacy`` (see :func:`_interp`). MAD reuses the sorted absolute
+    deviations from the median: in legacy mode at ``mad_frac`` (= 1 / original
+    ndim), otherwise the textbook median.
     """
     starts = np.zeros(n, np.int64)
     acc = 0
@@ -219,10 +222,10 @@ def segment_quantiles(values, seg0, counts, n, mad_frac):
         s = starts[k]
         seg = buf[s : s + cnt]
         seg.sort()
-        lq[k] = _interp(seg, cnt, 0.25)
-        med[k] = _interp(seg, cnt, 0.5)
-        uq[k] = _interp(seg, cnt, 0.75)
+        lq[k] = _interp(seg, cnt, 0.25, legacy)
+        med[k] = _interp(seg, cnt, 0.5, legacy)
+        uq[k] = _interp(seg, cnt, 0.75, legacy)
         ad = np.abs(seg - med[k])
         ad.sort()
-        mad[k] = _interp(ad, cnt, mad_frac)
+        mad[k] = _interp(ad, cnt, mad_frac if legacy else 0.5, legacy)
     return lq, med, uq, mad

--- a/test/test_backend_correctness.py
+++ b/test/test_backend_correctness.py
@@ -50,15 +50,32 @@ def _assert_dicts_match(ref, got):
 
 
 @requires_numba
+@pytest.mark.parametrize("legacy", [False, True], ids=["new", "legacy"])
 @pytest.mark.parametrize("edge", [True, False], ids=["edge", "noedge"])
 @pytest.mark.parametrize("dim", ["2d", "3d"])
-def test_numba_intensity_matches_numpy(dim, edge):
+def test_numba_intensity_matches_numpy(dim, edge, legacy):
     from cp_measure.core.numba import get_intensity as intensity_numba
 
     mask, pixels = _mask_pixels_2d() if dim == "2d" else _mask_pixels_3d()
-    ref = intensity_numpy(mask, pixels, edge_measurements=edge)
-    got = intensity_numba(mask, pixels, edge_measurements=edge)
+    ref = intensity_numpy(mask, pixels, edge_measurements=edge, legacy=legacy)
+    got = intensity_numba(mask, pixels, edge_measurements=edge, legacy=legacy)
     _assert_dicts_match(ref, got)
+
+
+def test_legacy_flag_anchor():
+    """Pin both backends to known numerical conventions on a tiny anchor case."""
+    mask = np.array([[1, 1, 1, 1]], dtype=np.int32)
+    pixels = np.array([[0.0, 1.0, 2.0, 3.0]])
+    new = intensity_numpy(mask, pixels, edge_measurements=False, legacy=False)
+    legacy = intensity_numpy(mask, pixels, edge_measurements=False, legacy=True)
+    # np.percentile defaults
+    np.testing.assert_allclose(new["Intensity_LowerQuartileIntensity"], [0.75])
+    np.testing.assert_allclose(new["Intensity_MedianIntensity"], [1.5])
+    np.testing.assert_allclose(new["Intensity_UpperQuartileIntensity"], [2.25])
+    # legacy: pos = n * q on a sorted segment
+    np.testing.assert_allclose(legacy["Intensity_LowerQuartileIntensity"], [1.0])
+    np.testing.assert_allclose(legacy["Intensity_MedianIntensity"], [2.0])
+    np.testing.assert_allclose(legacy["Intensity_UpperQuartileIntensity"], [3.0])
 
 
 @requires_numba


### PR DESCRIPTION
Stacked on top of #PERF_INTENSITY.

Adds `legacy: bool = False` to both intensity backends (numpy + numba) and threads it through `bulk` and the featurizer.

- `legacy=False` (new default): `numpy.percentile` 'linear' `(n-1)*q` quartiles + textbook `median(|x - median(x)|)` MAD.
- `legacy=True`: original cp_measure / CellProfiler `n*q` quartiles + `(1/ndim)`-quantile MAD (byte-for-byte the previous default).

Both backends share a single `_interp(sorted, n, frac, legacy)` helper. Parametrized test asserts numba==numpy under both flag values; anchor test pins exact values on `[0, 1, 2, 3]`.