### PR TITLE
fix(benchmark): source the harness from main, not the PR head

### DIFF
--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -1,45 +1,48 @@
 #!/usr/bin/env bash
-# Time every get_* in two isolated envs on IDENTICAL inputs, where only cp_measure.core differs:
-# HEAD's synth.py + _bench/ are vendored into the main worktree so generator/tooling changes can't
-# skew the comparison. Usage: run_benchmark.sh <matrix-preset> <out-dir> (from HEAD; needs origin/main).
+# Time every get_* in two isolated envs on IDENTICAL inputs, where only cp_measure.core differs.
+# Runs FROM a `main` checkout (which carries the tooling); the PR head supplies only the measurement
+# code. main's synth.py + _bench/ are vendored into the head worktree so a PR that doesn't carry the
+# tooling (the normal case) is still benchmarked, and generator/tooling changes can't skew it.
+# Usage: run_benchmark.sh <matrix-preset> <head-ref-or-sha> <out-dir>   (run from the main checkout)
 set -euo pipefail
 
 MATRIX="${1:-ci}"
-OUT="${2:-bench-out}"
-HEAD_DIR="$(pwd)"
+HEAD_REF="$2"
+OUT="${3:-bench-out}"
+MAIN_DIR="$(pwd)"
 WORK="$(mktemp -d)"
 SHARED="$WORK/fixtures"
 mkdir -p "$OUT"
-trap 'git worktree remove --force "$WORK/main" 2>/dev/null || true; rm -rf "$WORK"' EXIT
+trap 'git worktree remove --force "$WORK/head" 2>/dev/null || true; rm -rf "$WORK"' EXIT
 
 # Single-thread timing: representative (the repo forbids in-function parallelism) and low-noise.
 export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
        NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 NUMBA_NUM_THREADS=1
 
-vendor_tooling() {
-  cp "$HEAD_DIR/src/cp_measure/synth.py" "$1/src/cp_measure/synth.py"
+vendor_tooling() { # copy main's generator + bench tooling into the head worktree
+  cp "$MAIN_DIR/src/cp_measure/synth.py" "$1/src/cp_measure/synth.py"
   rm -rf "$1/src/cp_measure/_bench"
-  cp -r "$HEAD_DIR/src/cp_measure/_bench" "$1/src/cp_measure/_bench"
+  cp -r "$MAIN_DIR/src/cp_measure/_bench" "$1/src/cp_measure/_bench"
 }
 
-echo "::group::HEAD env: install, build fixtures, run"
-uv venv "$WORK/venv-head"
-uv pip install --python "$WORK/venv-head/bin/python" -e "$HEAD_DIR"
-"$WORK/venv-head/bin/python" -m cp_measure._bench.fixtures --out "$SHARED" --matrix "$MATRIX"
-"$WORK/venv-head/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/head.json"
-echo "::endgroup::"
-
-echo "::group::main worktree: vendor HEAD tooling, install, run (same fixtures)"
-git fetch --no-tags --depth=1 origin main
-git worktree add --detach "$WORK/main" origin/main
-vendor_tooling "$WORK/main"
+echo "::group::main env: install, build fixtures, run"
 uv venv "$WORK/venv-main"
-uv pip install --python "$WORK/venv-main/bin/python" -e "$WORK/main"
+uv pip install --python "$WORK/venv-main/bin/python" -e "$MAIN_DIR"
+"$WORK/venv-main/bin/python" -m cp_measure._bench.fixtures --out "$SHARED" --matrix "$MATRIX"
 "$WORK/venv-main/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/main.json"
 echo "::endgroup::"
 
+echo "::group::head worktree: vendor main tooling, install, run (same fixtures)"
+git fetch --no-tags --depth=1 origin "$HEAD_REF"
+git worktree add --detach "$WORK/head" FETCH_HEAD
+vendor_tooling "$WORK/head"
+uv venv "$WORK/venv-head"
+uv pip install --python "$WORK/venv-head/bin/python" -e "$WORK/head"
+"$WORK/venv-head/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/head.json"
+echo "::endgroup::"
+
 echo "::group::compare"
-"$WORK/venv-head/bin/python" -m cp_measure._bench.compare \
+"$WORK/venv-main/bin/python" -m cp_measure._bench.compare \
   --base "$OUT/main.json" --head "$OUT/head.json" --md "$OUT/table.md"
 cat "$OUT/table.md"
 echo "::endgroup::"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,18 +37,21 @@ jobs:
     timeout-minutes: 60
     permissions: {} # untrusted PR code runs here with no token
     steps:
-      - name: Checkout PR head (code under test)
+      - name: Checkout main (trusted tooling + baseline)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.head_ref }}
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Benchmark head vs main
-        run: bash .github/scripts/run_benchmark.sh "${{ github.event.inputs.matrix || 'ci' }}" bench-out
+      - name: Benchmark PR head vs main
+        run: >-
+          bash .github/scripts/run_benchmark.sh
+          "${{ github.event.inputs.matrix || 'ci' }}"
+          "${{ github.event.pull_request.head.sha || github.event.inputs.head_ref }}"
+          bench-out
       - name: Record PR number for the report job
         run: echo "${{ github.event.pull_request.number || github.event.inputs.pr }}" > bench-out/pr.txt
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
#80's workflow checked out the **PR head** and ran its `run_benchmark.sh`, but a perf PR doesn't carry the bench tooling (no `_bench/`, no script) — so it failed with `No such file or directory` (see PR #81's run).

Fix: check out **main** (trusted tooling + baseline), pass the PR head SHA to the driver, which fetches the head as a worktree, vendors main's `synth.py` + `_bench/` into it, installs, runs, and compares. Any perf PR is now benchmarkable without carrying the tooling.

After merge: on a labelled PR, remove+re-add the `benchmark` label to fire a fresh run.