### PR TITLE
feat(bench): synthetic-image PR performance benchmark action

### DIFF
--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Time every get_* in two isolated envs on IDENTICAL inputs, where only cp_measure.core differs.
+# Runs FROM a `main` checkout (which carries the tooling); the PR head supplies only the measurement
+# code. main's synth.py + _bench/ are vendored into the head worktree so a PR that doesn't carry the
+# tooling (the normal case) is still benchmarked, and generator/tooling changes can't skew it.
+# Usage: run_benchmark.sh <matrix-preset> <head-ref-or-sha> <out-dir>   (run from the main checkout)
+set -euo pipefail
+
+MATRIX="${1:-ci}"
+HEAD_REF="$2"
+OUT="${3:-bench-out}"
+MAIN_DIR="$(pwd)"
+WORK="$(mktemp -d)"
+SHARED="$WORK/fixtures"
+mkdir -p "$OUT"
+trap 'git worktree remove --force "$WORK/head" 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+# Single-thread timing: representative (the repo forbids in-function parallelism) and low-noise.
+export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+       NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 NUMBA_NUM_THREADS=1
+
+vendor_tooling() { # copy main's generator + bench tooling into the head worktree
+  cp "$MAIN_DIR/src/cp_measure/synth.py" "$1/src/cp_measure/synth.py"
+  rm -rf "$1/src/cp_measure/_bench"
+  cp -r "$MAIN_DIR/src/cp_measure/_bench" "$1/src/cp_measure/_bench"
+}
+
+echo "::group::main env: install, build fixtures, run"
+uv venv "$WORK/venv-main"
+uv pip install --python "$WORK/venv-main/bin/python" -e "$MAIN_DIR"
+"$WORK/venv-main/bin/python" -m cp_measure._bench.fixtures --out "$SHARED" --matrix "$MATRIX"
+"$WORK/venv-main/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/main.json"
+echo "::endgroup::"
+
+echo "::group::head worktree: vendor main tooling, install, run (same fixtures)"
+git fetch --no-tags --depth=1 origin "$HEAD_REF"
+git worktree add --detach "$WORK/head" FETCH_HEAD
+vendor_tooling "$WORK/head"
+uv venv "$WORK/venv-head"
+uv pip install --python "$WORK/venv-head/bin/python" -e "$WORK/head"
+"$WORK/venv-head/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/head.json"
+echo "::endgroup::"
+
+echo "::group::compare"
+"$WORK/venv-main/bin/python" -m cp_measure._bench.compare \
+  --base "$OUT/main.json" --head "$OUT/head.json" --md "$OUT/table.md"
+cat "$OUT/table.md"
+echo "::endgroup::"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,91 @@
+name: benchmark
+
+# Times every public get_* function on the PR head vs current `main` and posts a sticky comment.
+#
+# Security model (two-job split):
+#  - `build` runs untrusted PR code (pip install + the functions) with `permissions: {}` — NO token,
+#    nothing to steal, persist-credentials disabled. Labels can only be applied by users with write
+#    access, so the label trigger is inherently maintainer-gated.
+#  - `report` holds the write token but NEVER checks out PR code; it only renders the artifact.
+#
+# Test the workflow itself with `workflow_dispatch` (pull_request_target always runs the base copy).
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      head_ref:
+        description: branch or SHA to benchmark vs main
+        required: true
+      pr:
+        description: PR number to comment on (optional)
+        required: false
+      matrix:
+        description: matrix preset (ci | default | smoke)
+
+permissions: {}
+
+concurrency:
+  group: bench-${{ github.event.pull_request.number || github.event.inputs.pr || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'benchmark' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: {} # untrusted PR code runs here with no token
+    steps:
+      - name: Checkout main (trusted tooling + baseline)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Benchmark PR head vs main
+        run: >-
+          bash .github/scripts/run_benchmark.sh
+          "${{ github.event.inputs.matrix || 'ci' }}"
+          "${{ github.event.pull_request.head.sha || github.event.inputs.head_ref }}"
+          bench-out
+      - name: Record PR number for the report job
+        run: echo "${{ github.event.pull_request.number || github.event.inputs.pr }}" > bench-out/pr.txt
+      - uses: actions/upload-artifact@v4
+        if: always() # surface partial output even if the benchmark step fails
+        with:
+          name: bench-out
+          path: bench-out/
+
+  report:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write # PR labels/comments go through the issues API
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: bench-out
+          path: bench-out
+      - name: Post sticky comment and remove the trigger label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PR="$(tr -d '[:space:]' < bench-out/pr.txt)"
+          if [ -z "$PR" ]; then echo "no PR number; nothing to post"; exit 0; fi
+          { echo '<!-- cp-bench -->'; echo; cat bench-out/table.md; } > bench-out/comment.md
+          CID="$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+                 --jq 'map(select(.body | startswith("<!-- cp-bench -->")))[0].id // empty')"
+          if [ -n "$CID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@bench-out/comment.md >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@bench-out/comment.md >/dev/null
+          fi
+          # Remove the trigger label so re-labelling can re-run (label path only; ignore on dispatch).
+          gh api -X DELETE "repos/$REPO/issues/$PR/labels/benchmark" >/dev/null 2>&1 || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 __pycache__/
 /.agent-shell/
 .pre-commit-config.yaml
+
+# local benchmark artifacts
+bench-out/
+*.npz

--- a/src/cp_measure/_bench/compare.py
+++ b/src/cp_measure/_bench/compare.py
@@ -1,0 +1,123 @@
+"""Compare two ``run.py`` JSON outputs into a timing table.
+
+Per (function, size, count) it shows the ``main`` and ``head`` time as mean (min–max) over
+reps×seeds and the raw ratio ``main/head``. No pass/fail classification and no normalisation —
+read the function you changed and judge the spread from its own min–max. Functions present on only
+one side are flagged ``new``/``removed``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+
+def _cell_groups(report: dict) -> dict:
+    """Map (size, n_objects) -> [fixture keys] from a report's fixtures list."""
+    groups: dict[tuple[int, int], list[str]] = {}
+    for e in report["fixtures"]:
+        groups.setdefault((e["size"], e["n_objects"]), []).append(e["key"])
+    return groups
+
+
+def _stats(results_for_fn: dict, keys: list[str]):
+    """(mean, min, max) in ms over all ok rep times of a cell, or None if none timed."""
+    times = [
+        t
+        for k in keys
+        if results_for_fn.get(k, {}).get("status") == "ok"
+        for t in results_for_fn[k]["reps"]
+    ]
+    if not times:
+        return None
+    return statistics.mean(times) * 1e3, min(times) * 1e3, max(times) * 1e3
+
+
+def compare(base: dict, head: dict) -> list[dict]:
+    groups = _cell_groups(head)  # head defines the matrix
+    base_r, head_r = base["results"], head["results"]
+    rows = []
+    for fn in sorted(head_r):
+        for (size, n_objects), keys in sorted(groups.items()):
+            m = _stats(base_r.get(fn, {}), keys)
+            h = _stats(head_r[fn], keys)
+            rows.append(
+                {
+                    "function": fn,
+                    "size": size,
+                    "n_objects": n_objects,
+                    "main": m,
+                    "head": h,
+                    "speedup": (m[0] / h[0]) if (m and h) else None,
+                    "note": "" if fn in base_r else "new",
+                }
+            )
+    for fn in sorted(set(base_r) - set(head_r)):
+        rows.append(
+            {
+                "function": fn,
+                "size": None,
+                "n_objects": None,
+                "main": None,
+                "head": None,
+                "speedup": None,
+                "note": "removed",
+            }
+        )
+    return rows
+
+
+def _ms(stat) -> str:
+    return "—" if stat is None else f"{stat[0]:.1f} ({stat[1]:.1f}–{stat[2]:.1f})"
+
+
+def render_markdown(rows: list[dict], base_meta: dict, head_meta: dict) -> str:
+    m = head_meta.get("matrix") or {}
+    scope = (
+        f"{m.get('sizes')}×{m.get('counts')}×{len(m.get('seeds', []))} seeds"
+        if m
+        else "?"
+    )
+    lines = [
+        "### Benchmark — PR head vs `main`",
+        "",
+        f"time = mean (min–max) ms over reps×seeds · `speedup = main/head` · "
+        f"synth v{head_meta.get('synth_version')} · {head_meta.get('n_fixtures')} fixtures "
+        f"({scope}) · reps={head_meta.get('reps')}, threads=1",
+        "",
+        "| function | size | objects | main (ms) | head (ms) | speedup |",
+        "|---|--:|--:|--:|--:|--:|",
+    ]
+    for r in rows:
+        label = f"`{r['function']}`" + (f" _{r['note']}_" if r["note"] else "")
+        sz = "—" if r["size"] is None else r["size"]
+        no = "—" if r["n_objects"] is None else r["n_objects"]
+        sp = "—" if r["speedup"] is None else f"{r['speedup']:.2f}×"
+        lines.append(
+            f"| {label} | {sz} | {no} | {_ms(r['main'])} | {_ms(r['head'])} | {sp} |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Compare two run.py JSON outputs into a timing table."
+    )
+    p.add_argument("--base", required=True, help="main run JSON")
+    p.add_argument("--head", required=True, help="head run JSON")
+    p.add_argument("--md", help="write the markdown table here (default: stdout)")
+    a = p.parse_args(argv)
+    base = json.loads(Path(a.base).read_text())
+    head = json.loads(Path(a.head).read_text())
+    md = render_markdown(compare(base, head), base["meta"], head["meta"])
+    if a.md:
+        Path(a.md).write_text(md)
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cp_measure/_bench/fixtures.py
+++ b/src/cp_measure/_bench/fixtures.py
@@ -1,0 +1,107 @@
+"""Build the (image_size × object_count × seed) fixture matrix once from the pinned ``synth``
+generator into ``.npz`` + a sha256 manifest, so ``main`` and the PR head load identical inputs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy
+
+from cp_measure import synth
+
+# Matrix presets. The default object counts are feasible at the smallest image (512² packs ~180);
+# fixed counts across sizes isolate area-scaling (size↑) from per-object cost (count↑).
+DEFAULT_MATRIX = {
+    "sizes": (512, 1024, 2048),
+    "counts": (16, 48, 96, 144),
+    "seeds": (0, 1, 2),
+}
+# CI default: bounded so the full sweep stays well within a hosted runner's memory/time budget
+# (the 2048²×144 corner of DEFAULT can OOM/overrun). Use DEFAULT via workflow_dispatch for depth.
+CI_MATRIX = {"sizes": (512, 1024), "counts": (16, 64), "seeds": (0, 1)}
+SMOKE_MATRIX = {"sizes": (128,), "counts": (4, 8), "seeds": (0,)}
+
+MATRICES = {"default": DEFAULT_MATRIX, "ci": CI_MATRIX, "smoke": SMOKE_MATRIX}
+
+MANIFEST_NAME = "manifest.json"
+
+
+def spec_key(size: int, n_objects: int, seed: int) -> str:
+    return f"s{size}_n{n_objects}_seed{seed}"
+
+
+def _digest(labels: numpy.ndarray, channels: numpy.ndarray) -> str:
+    h = hashlib.sha256()
+    h.update(labels.tobytes())
+    h.update(channels.tobytes())
+    return h.hexdigest()
+
+
+def build_fixtures(out_dir: str | Path, matrix: dict = DEFAULT_MATRIX) -> dict:
+    """Generate every (size, count, seed) fixture into ``out_dir`` and write ``manifest.json``."""
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    entries = []
+    for size in matrix["sizes"]:
+        for n_objects in matrix["counts"]:
+            for seed in matrix["seeds"]:
+                labels, channels = synth.generate(
+                    size, n_objects, n_channels=2, seed=seed
+                )
+                key = spec_key(size, n_objects, seed)
+                numpy.savez(out / f"{key}.npz", labels=labels, channels=channels)
+                entries.append(
+                    {
+                        "key": key,
+                        "size": size,
+                        "n_objects": n_objects,
+                        "seed": seed,
+                        "file": f"{key}.npz",
+                        "sha256": _digest(labels, channels),
+                    }
+                )
+    manifest = {
+        "synth_version": synth.__version__,
+        "matrix": {k: list(v) for k, v in matrix.items()},
+        "fixtures": entries,
+    }
+    (out / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+def load_manifest(fixtures_dir: str | Path) -> dict:
+    return json.loads((Path(fixtures_dir) / MANIFEST_NAME).read_text())
+
+
+def load_fixture(fixtures_dir: str | Path, entry: dict):
+    """Load ``(labels, channels)`` for one manifest entry, checking its sha256."""
+    data = numpy.load(Path(fixtures_dir) / entry["file"])
+    labels, channels = data["labels"], data["channels"]
+    if _digest(labels, channels) != entry["sha256"]:
+        raise ValueError(
+            f"fixture {entry['key']} sha256 mismatch — corrupt or wrong generator"
+        )
+    return labels, channels
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(description="Build the benchmark fixture matrix.")
+    p.add_argument("--out", required=True, help="output directory")
+    p.add_argument(
+        "--matrix", default="ci", choices=sorted(MATRICES), help="matrix preset"
+    )
+    a = p.parse_args(argv)
+    m = build_fixtures(a.out, MATRICES[a.matrix])
+    print(
+        f"built {len(m['fixtures'])} fixtures (matrix={a.matrix}, synth v{m['synth_version']}) -> {a.out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cp_measure/_bench/run.py
+++ b/src/cp_measure/_bench/run.py
@@ -1,0 +1,193 @@
+"""Time every public ``get_*`` function over a fixture matrix → JSON (run per env; compare.py diffs two).
+
+Functions come from the live ``bulk`` registry at HEAD (a PR-added feature is timed, reported "new").
+Each channel is normalised to ``[0, 1]`` (``get_texture`` requires it); calls are positional per arity:
+core ``fn(labels, img)``, correlation ``fn(img1, img2, labels)``.
+"""
+
+from __future__ import annotations
+
+# Thread pinning MUST precede numpy/BLAS import: single-thread timing is representative because the
+# repo forbids parallelism inside feature functions, and it removes contention noise. The CI driver
+# also sets these; we set them defensively here before any numpy import.
+import os
+
+for _var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMBA_NUM_THREADS",
+):
+    os.environ.setdefault(_var, "1")
+
+import argparse  # noqa: E402
+import inspect  # noqa: E402
+import json  # noqa: E402
+import signal  # noqa: E402
+from contextlib import contextmanager  # noqa: E402
+from dataclasses import dataclass  # noqa: E402
+from pathlib import Path  # noqa: E402
+from time import perf_counter  # noqa: E402
+
+from cp_measure._bench import fixtures  # noqa: E402
+
+DEFAULT_WARMUP = 1
+DEFAULT_REPS = 5
+DEFAULT_TIMEOUT = 120.0
+
+
+@dataclass
+class Func:
+    label: str
+    fn: object
+    arity: int
+    kwargs: dict
+
+
+class _Timeout(Exception):
+    pass
+
+
+@contextmanager
+def _time_limit(seconds: float):
+    def _handler(signum, frame):
+        raise _Timeout()
+
+    old = signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old)
+
+
+def _has_legacy(fn) -> bool:
+    fn = getattr(fn, "func", fn)  # unwrap functools.partial
+    try:
+        return "legacy" in inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def enumerate_functions() -> list[Func]:
+    """All public get_* functions from the live registries, plus a [legacy] variant where supported."""
+    from cp_measure import bulk
+
+    out: list[Func] = []
+    for arity, registry in (
+        (1, bulk.get_core_measurements()),
+        (2, bulk.get_correlation_measurements()),
+    ):
+        for name, fn in registry.items():
+            out.append(Func(name, fn, arity, {}))
+            # [legacy] reuses the same fn, so for a numba backend it shares the base variant's
+            # JIT-warmed code — read the legacy-vs-base delta with that caveat.
+            if _has_legacy(fn):
+                out.append(Func(f"{name}[legacy]", fn, arity, {"legacy": True}))
+    return out
+
+
+def _norm01(image):
+    image = image.astype("float64")
+    lo, hi = float(image.min()), float(image.max())
+    return (image - lo) / (hi - lo) if hi > lo else image - lo  # constant image → zeros
+
+
+def _call_args(func: Func, labels, channels):
+    if func.arity == 1:
+        return (labels, _norm01(channels[0]))
+    return (_norm01(channels[0]), _norm01(channels[1]), labels)
+
+
+def time_call(func: Func, args, warmup: int, reps: int, timeout: float) -> dict:
+    try:
+        with _time_limit(timeout):
+            for _ in range(warmup):
+                func.fn(*args, **func.kwargs)
+            times = []
+            for _ in range(reps):
+                t0 = perf_counter()
+                func.fn(*args, **func.kwargs)
+                times.append(perf_counter() - t0)
+    except _Timeout:
+        return {"status": "timeout", "timeout_s": timeout}
+    except (
+        Exception
+    ) as exc:  # a function that can't handle the synthetic input — recorded, not fatal
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"[:200]}
+    return {"status": "ok", "reps": times}
+
+
+def run(
+    fixtures_dir,
+    out_path,
+    warmup=DEFAULT_WARMUP,
+    reps=DEFAULT_REPS,
+    timeout=DEFAULT_TIMEOUT,
+):
+    manifest = fixtures.load_manifest(fixtures_dir)
+    funcs = enumerate_functions()
+    results: dict[str, dict] = {f.label: {} for f in funcs}
+    # Outer loop over fixtures so each .npz is loaded (and sha-verified) once.
+    for entry in manifest["fixtures"]:
+        labels, channels = fixtures.load_fixture(fixtures_dir, entry)
+        for func in funcs:
+            try:
+                args = _call_args(func, labels, channels)
+            except Exception as exc:  # e.g. correlation fn on a 1-channel fixture
+                results[func.label][entry["key"]] = {
+                    "status": "error",
+                    "error": str(exc)[:200],
+                }
+                continue
+            results[func.label][entry["key"]] = time_call(
+                func, args, warmup, reps, timeout
+            )
+
+    out = {
+        "meta": {
+            "synth_version": manifest["synth_version"],
+            "matrix": manifest["matrix"],
+            "n_fixtures": len(manifest["fixtures"]),
+            "n_functions": len(funcs),
+            "warmup": warmup,
+            "reps": reps,
+            "timeout_s": timeout,
+            "threads": os.environ.get("OMP_NUM_THREADS"),
+        },
+        "fixtures": manifest["fixtures"],
+        "results": results,
+    }
+    Path(out_path).write_text(json.dumps(out, indent=2))
+    return out
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Time all get_* functions over a fixture matrix."
+    )
+    p.add_argument(
+        "--fixtures", required=True, help="fixtures dir (with manifest.json)"
+    )
+    p.add_argument("--out", required=True, help="output JSON path")
+    p.add_argument("--warmup", type=int, default=DEFAULT_WARMUP)
+    p.add_argument("--reps", type=int, default=DEFAULT_REPS)
+    p.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    a = p.parse_args(argv)
+    out = run(a.fixtures, a.out, a.warmup, a.reps, a.timeout)
+    ok = sum(
+        1 for fn in out["results"].values() for c in fn.values() if c["status"] == "ok"
+    )
+    total = sum(len(c) for c in out["results"].values())
+    print(
+        f"timed {out['meta']['n_functions']} functions over {len(out['fixtures'])} fixtures "
+        f"({ok}/{total} cells ok) -> {a.out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cp_measure/synth.py
+++ b/src/cp_measure/synth.py
@@ -1,0 +1,246 @@
+"""Deterministic synthetic cell images for benchmarking.
+
+``generate(image_size, n_objects, n_channels, seed)`` returns a contiguous ``1..n`` label mask of
+organic, non-overlapping cells (no degenerate ~1px objects) plus intensity channels that share a
+smooth envelope (cross-channel correlation < 1, for colocalisation) over independent multi-scale
+Gaussian splats (area/intensity/texture signal). Output is reproducible only against the pinned
+``__version__`` (stamped into benchmark comments); an ``n_objects`` that cannot fit raises.
+"""
+
+from __future__ import annotations
+
+import numpy
+import scipy.ndimage
+from numpy.typing import NDArray
+
+__version__ = "0.2.0"
+
+# Cell geometry. Sizes are fixed in px (NOT derived from n_objects) so the object-count sweep
+# isolates per-object cost without shrinking the cells.
+_MEAN_RADIUS = 8.0  # median base radius, px
+_RADIUS_LOGSIGMA = 0.35  # log-normal size spread
+_MIN_RADIUS = 3.5  # lower clamp, keeps cells above the degenerate floor
+_MAX_RADIUS_FACTOR = 2.2  # upper clamp (× mean), also caps packing waste
+_GAP = 2.0  # minimum margin between cells, px
+_N_HARMONICS = 3  # low Fourier harmonics → organic, non-convex boundary
+_HARMONIC_AMP = 0.12  # per-harmonic radial wobble (fraction of base radius)
+_FILL_LIMIT = 0.45  # max halo-padded area fraction before placement refuses
+
+# Channel synthesis: a shared splat field correlates the channels, independent fields keep r < 1.
+_SHARED_SPLATS_PER_CELL = 6
+_INDEP_SPLATS_PER_CELL = 7
+_BG_LEVEL = 0.05
+_ENVELOPE_WEIGHT = 0.5
+_NOISE_LEVEL = 0.05  # read-noise std
+
+
+def generate(
+    image_size: int,
+    n_objects: int,
+    n_channels: int = 2,
+    seed: int = 0,
+) -> tuple[NDArray[numpy.int32], NDArray[numpy.float32]]:
+    """Return (labels ``int32 [S,S]``, channels ``float32 [C,S,S]``); raises if cells can't fit.
+
+    Core features consume channel 0; colocalisation consumes channels 0 and 1.
+    """
+    if n_channels < 1:
+        raise ValueError(f"n_channels must be >= 1, got {n_channels}")
+    if n_objects < 0:
+        raise ValueError(f"n_objects must be >= 0, got {n_objects}")
+
+    rng = numpy.random.default_rng(seed)
+    labels = _build_label_mask(rng, image_size, n_objects)
+    channels = _build_channels(rng, labels, n_channels)
+    return labels, channels
+
+
+def _draw_radii(rng: numpy.random.Generator, n: int) -> NDArray[numpy.float64]:
+    """Per-cell base radii from a clamped log-normal (variety: big + tiny cells)."""
+    r = _MEAN_RADIUS * numpy.exp(rng.normal(0.0, _RADIUS_LOGSIGMA, size=n))
+    return numpy.clip(r, _MIN_RADIUS, _MEAN_RADIUS * _MAX_RADIUS_FACTOR)
+
+
+def _cell_extent(base_r, amps):
+    """Max radial reach ``base_r*(1+Σ|amps|)`` — the single source for both the packing radius
+    (worst-case amps) and the raster window (actual amps), so the two can't drift and break
+    no-overlap. ``base_r`` scalar or array; ``amps`` summed over its last axis."""
+    return base_r * (1.0 + numpy.sum(numpy.abs(amps)))
+
+
+def _build_label_mask(
+    rng: numpy.random.Generator, image_size: int, n_objects: int
+) -> NDArray[numpy.int32]:
+    labels = numpy.zeros((image_size, image_size), dtype=numpy.int32)
+    if n_objects == 0:
+        return labels
+
+    # Big cells first (easier packing); stable sort keeps tied radii ordered across numpy builds.
+    radii = numpy.sort(_draw_radii(rng, n_objects), kind="stable")[::-1]
+    # Packing/capacity use the worst-case boundary: every harmonic at its extreme amplitude.
+    bulge = _cell_extent(radii, numpy.full(_N_HARMONICS, _HARMONIC_AMP))
+
+    halo_area = float(numpy.sum(numpy.pi * (bulge + _GAP) ** 2))
+    if halo_area > _FILL_LIMIT * image_size * image_size:
+        raise ValueError(
+            f"cannot fit {n_objects} cells in {image_size}x{image_size}: they need "
+            f"{halo_area / image_size**2:.0%} of the image (limit {_FILL_LIMIT:.0%}). "
+            f"Use a larger image or fewer objects."
+        )
+
+    centers = _place_centers(rng, image_size, bulge)
+
+    # Rasterise each organic cell. Placement guarantees the bulge disks are disjoint, so labels
+    # never collide; the `== 0` guard is belt-and-braces against boundary rounding.
+    for k, (cy, cx, base_r) in enumerate(
+        zip(centers[:, 0], centers[:, 1], radii), start=1
+    ):
+        amps = rng.uniform(-_HARMONIC_AMP, _HARMONIC_AMP, size=_N_HARMONICS)
+        phases = rng.uniform(0.0, 2.0 * numpy.pi, size=_N_HARMONICS)
+        win_mask, (y0, x0, y1, x1) = _rasterize_cell(
+            image_size, cy, cx, base_r, amps, phases
+        )
+        sub = labels[y0:y1, x0:x1]
+        sub[win_mask & (sub == 0)] = k
+
+    realized = numpy.unique(labels)
+    realized = realized[realized > 0]
+    if realized.size != n_objects:
+        raise ValueError(
+            f"requested {n_objects} objects but rasterised {realized.size}; "
+            f"a cell was fully occluded — widen _GAP or lower the count."
+        )
+    return labels
+
+
+def _place_centers(
+    rng: numpy.random.Generator, image_size: int, bulge: NDArray[numpy.float64]
+) -> NDArray[numpy.float64]:
+    """Dart-throw centers so bulge disks are pairwise separated by at least ``_GAP``.
+
+    Big cells (front of ``bulge``) are placed first. Raises if the per-object attempt budget is
+    exhausted — never returns fewer than requested.
+    """
+    n = bulge.size
+    centers = numpy.empty((n, 2), dtype=numpy.float64)
+    placed = 0
+    budget = 200 * n + 1000
+    attempts = 0
+    while placed < n:
+        r = bulge[placed]
+        cy = rng.uniform(r, image_size - r)
+        cx = rng.uniform(r, image_size - r)
+        if placed == 0:
+            ok = True
+        else:
+            dist = numpy.hypot(centers[:placed, 0] - cy, centers[:placed, 1] - cx)
+            ok = bool(numpy.all(dist >= r + bulge[:placed] + _GAP))
+        if ok:
+            centers[placed] = (cy, cx)
+            placed += 1
+        attempts += 1
+        if attempts > budget:
+            raise ValueError(
+                f"could not place {n} cells in {image_size}x{image_size} within the attempt "
+                f"budget ({placed} placed); the layout is too dense — lower the count."
+            )
+    return centers
+
+
+def _rasterize_cell(
+    image_size: int,
+    cy: float,
+    cx: float,
+    base_r: float,
+    amps: NDArray[numpy.float64],
+    phases: NDArray[numpy.float64],
+) -> tuple[NDArray[numpy.bool_], tuple[int, int, int, int]]:
+    """Boolean mask of one organic star-shaped cell, plus its ``(y0, x0, y1, x1)`` window."""
+    reach = _cell_extent(base_r, amps)  # same definition the packing radius uses
+    y0 = max(0, int(numpy.floor(cy - reach)))
+    x0 = max(0, int(numpy.floor(cx - reach)))
+    y1 = min(image_size, int(numpy.ceil(cy + reach)) + 1)
+    x1 = min(image_size, int(numpy.ceil(cx + reach)) + 1)
+    yy, xx = numpy.mgrid[y0:y1, x0:x1]
+    dy = yy - cy
+    dx = xx - cx
+    dist = numpy.hypot(dy, dx)
+    theta = numpy.arctan2(dy, dx)
+    harmonics = numpy.arange(1, _N_HARMONICS + 1)[:, None, None]
+    wobble = numpy.sum(
+        amps[:, None, None]
+        * numpy.cos(harmonics * theta[None] + phases[:, None, None]),
+        axis=0,
+    )
+    boundary = base_r * (1.0 + wobble)
+    return dist <= boundary, (y0, x0, y1, x1)
+
+
+def _build_channels(
+    rng: numpy.random.Generator, labels: NDArray[numpy.int32], n_channels: int
+) -> NDArray[numpy.float32]:
+    image_size = labels.shape[0]
+    fg = labels > 0
+    # Shared smooth envelope: bright on/near cells, identical across channels → drives a positive
+    # cross-channel correlation that the independent splats then pull back below 1.
+    envelope = scipy.ndimage.gaussian_filter(
+        fg.astype(numpy.float64), sigma=_MEAN_RADIUS
+    )
+    if envelope.max() > 0:
+        envelope /= envelope.max()
+
+    fg_idx = numpy.flatnonzero(fg)
+    n_objects = int(labels.max())
+    # A splat field shared by every channel plus one independent field per channel: the shared
+    # part correlates the channels (colocalisation signal), the independent part keeps r < 1.
+    shared_splats = _splat_field(
+        rng, image_size, fg_idx, n_objects * _SHARED_SPLATS_PER_CELL
+    )
+    base = _BG_LEVEL + _ENVELOPE_WEIGHT * envelope + shared_splats
+
+    channels = numpy.empty((n_channels, image_size, image_size), dtype=numpy.float32)
+    for c in range(n_channels):
+        img = base + _splat_field(
+            rng, image_size, fg_idx, n_objects * _INDEP_SPLATS_PER_CELL
+        )
+        img += rng.normal(0.0, _NOISE_LEVEL, size=img.shape)
+        numpy.clip(img, 0.0, None, out=img)
+        channels[c] = img.astype(numpy.float32)
+    return channels
+
+
+def _splat_field(
+    rng: numpy.random.Generator,
+    image_size: int,
+    fg_idx: NDArray[numpy.intp],
+    n_splats: int,
+) -> NDArray[numpy.float64]:
+    """Sum of multi-scale 2D Gaussians centred on cell pixels (texture signal; tails bleed past edges)."""
+    field = numpy.zeros((image_size, image_size), dtype=numpy.float64)
+    if n_splats == 0 or fg_idx.size == 0:
+        return field
+    picks = fg_idx[rng.integers(0, fg_idx.size, size=n_splats)]
+    ys, xs = numpy.divmod(picks, image_size)
+    # Scale mixture: tiny puncta dominate (texture), with fewer mid blobs and a few large gradients.
+    # Inverse-CDF sampling on rng.random (version-stable draw count, unlike rng.choice(p=...)).
+    scales = numpy.array([1.2, 3.0, 6.0])
+    cum_weights = numpy.array([0.6, 0.9, 1.0])
+    scale_choice = scales[numpy.searchsorted(cum_weights, rng.random(n_splats))]
+    amps = rng.uniform(0.3, 1.0, size=n_splats)
+    for cy, cx, sigma, amp in zip(ys, xs, scale_choice, amps):
+        _add_gaussian(field, int(cy), int(cx), float(sigma), float(amp))
+    return field
+
+
+def _add_gaussian(
+    field: NDArray[numpy.float64], cy: int, cx: int, sigma: float, amp: float
+) -> None:
+    """Add ``amp * exp(-r^2 / 2 sigma^2)`` onto a bounded window around ``(cy, cx)``."""
+    rad = max(1, int(numpy.ceil(3.0 * sigma)))
+    size = field.shape[0]
+    y0, y1 = max(0, cy - rad), min(size, cy + rad + 1)
+    x0, x1 = max(0, cx - rad), min(size, cx + rad + 1)
+    yy, xx = numpy.mgrid[y0:y1, x0:x1]
+    field[y0:y1, x0:x1] += amp * numpy.exp(
+        -((yy - cy) ** 2 + (xx - cx) ** 2) / (2.0 * sigma * sigma)
+    )

--- a/test/test_bench.py
+++ b/test/test_bench.py
@@ -1,0 +1,81 @@
+"""Tests for the benchmark fixture/runner/comparator (cp_measure._bench)."""
+
+import time
+
+import pytest
+
+from cp_measure._bench import compare, fixtures, run
+
+SMOKE = fixtures.SMOKE_MATRIX
+
+
+def test_fixtures_build_load_and_determinism(tmp_path):
+    a = fixtures.build_fixtures(tmp_path / "a", SMOKE)
+    b = fixtures.build_fixtures(tmp_path / "b", SMOKE)
+    assert a["synth_version"] == fixtures.synth.__version__
+    sha = lambda m: {e["key"]: e["sha256"] for e in m["fixtures"]}  # noqa: E731
+    assert sha(a) == sha(b)  # deterministic across builds
+    labels, channels = fixtures.load_fixture(
+        tmp_path / "a", a["fixtures"][0]
+    )  # verifies sha256
+    assert labels.shape == (128, 128) and channels.shape == (2, 128, 128)
+    with pytest.raises(ValueError, match="sha256 mismatch"):
+        fixtures.load_fixture(tmp_path / "a", {**a["fixtures"][0], "sha256": "0" * 64})
+
+
+def test_run_enumerates_and_times_all_functions(tmp_path):
+    from cp_measure import bulk
+
+    expected = set(bulk.get_core_measurements()) | set(
+        bulk.get_correlation_measurements()
+    )
+    assert {
+        f.label for f in run.enumerate_functions() if "[legacy]" not in f.label
+    } == expected
+    fixtures.build_fixtures(tmp_path, SMOKE)
+    out = run.run(tmp_path, tmp_path / "r.json", warmup=0, reps=1, timeout=60)
+    statuses = [c["status"] for fn in out["results"].values() for c in fn.values()]
+    assert statuses and all(
+        s == "ok" for s in statuses
+    )  # incl. texture (needs [0,1] norm)
+
+
+def test_time_call_error_and_timeout():
+    class _F:
+        def __init__(self, fn):
+            self.fn, self.kwargs = fn, {}
+
+    def boom(*a):
+        raise RuntimeError("nope")
+
+    assert run.time_call(_F(boom), (), 0, 1, 5)["status"] == "error"
+    assert (
+        run.time_call(_F(lambda *a: time.sleep(1)), (), 0, 1, 0.05)["status"]
+        == "timeout"
+    )
+
+
+def _report(times):
+    fix = [{"key": "k", "size": 128, "n_objects": 4, "seed": 0}]
+    results = {fn: {"k": {"status": "ok", "reps": [s]}} for fn, s in times.items()}
+    return {
+        "meta": {"synth_version": "0", "reps": 1},
+        "fixtures": fix,
+        "results": results,
+    }
+
+
+def test_compare_reports_timings_and_renders():
+    base = _report({"win": 0.010, "gone": 0.010, "err": 0.010})
+    head = _report({"win": 0.005, "fresh": 0.010, "err": 0.010})
+    head["results"]["err"]["k"] = {"status": "error", "error": "x"}
+    rows = {r["function"]: r for r in compare.compare(base, head)}
+    assert rows["win"]["speedup"] == pytest.approx(2.0)
+    assert rows["win"]["main"][0] == pytest.approx(10.0)  # mean ms
+    assert rows["fresh"]["note"] == "new" and rows["fresh"]["speedup"] is None
+    assert rows["gone"]["note"] == "removed"
+    assert rows["err"]["speedup"] is None  # errored on head → no head timing
+    md = compare.render_markdown(
+        compare.compare(base, head), base["meta"], head["meta"]
+    )
+    assert "speedup = main/head" in md and "2.00×" in md and "min–max" in md

--- a/test/test_synth.py
+++ b/test/test_synth.py
@@ -1,0 +1,48 @@
+"""Regression checks for the synthetic benchmark generator ``cp_measure.synth``."""
+
+import numpy
+import pytest
+import scipy.ndimage
+from skimage.measure import regionprops_table
+
+from cp_measure import synth
+
+CONFIG = (512, 80)  # enough objects for stats, fast to generate
+
+
+def test_generate_invariants():
+    size, n = CONFIG
+    labels, channels = synth.generate(size, n, n_channels=2, seed=0)
+    # shape / dtype / contiguous 1..n labels at the requested count (cp_measure's contract)
+    assert labels.shape == (size, size) and labels.dtype == numpy.int32
+    assert channels.shape == (2, size, size) and channels.dtype == numpy.float32
+    assert numpy.array_equal(numpy.unique(labels)[1:], numpy.arange(1, n + 1))
+    # no degenerate (~1px) objects; some shape and size variety
+    areas = numpy.bincount(labels.ravel())[1:]
+    assert areas.min() >= 20
+    rp = regionprops_table(labels, properties=("eccentricity", "area"))
+    assert rp["eccentricity"].max() - rp["eccentricity"].min() > 0.2
+    assert rp["area"].max() / rp["area"].min() > 2
+    # real signal: cells brighter than background, texture above noise, coloc in a controlled band
+    fg = labels > 0
+    assert channels[0][fg].mean() > channels[0][~fg].mean()
+    stds = scipy.ndimage.standard_deviation(channels[0], labels, numpy.arange(1, n + 1))
+    assert numpy.median(stds) > 5 * synth._NOISE_LEVEL
+    r = numpy.corrcoef(channels[0][fg], channels[1][fg])[0, 1]
+    assert 0.2 < r < 0.9
+
+
+def test_determinism():
+    a = synth.generate(256, 20, seed=1)
+    b = synth.generate(256, 20, seed=1)
+    assert numpy.array_equal(a[0], b[0]) and numpy.array_equal(a[1], b[1])
+    assert not numpy.array_equal(synth.generate(256, 20, seed=2)[0], a[0])
+
+
+def test_edges():
+    labels, channels = synth.generate(
+        128, 0, n_channels=1, seed=0
+    )  # empty + single channel
+    assert labels.max() == 0 and channels.shape == (1, 128, 128)
+    with pytest.raises(ValueError, match="cannot fit"):
+        synth.generate(256, 5000, seed=0)


### PR DESCRIPTION
Re-introduces the benchmark mechanic (reverted in #83) as one clean commit, with the harness-source fix folded in.

Label a PR `benchmark` (or `workflow_dispatch`) → times every public `get_*` on the PR head vs `main` over a synthetic-image matrix → posts a sticky comment with raw `mean (min–max)` timings and the `main/head` ratio per function. Read the function you changed; no pass/fail classification.

- `cp_measure/synth.py` — deterministic generator: contiguous `1..n` cells, channels with area/intensity/texture/coloc signal, capacity-checked, `__version__`-stamped.
- `cp_measure/_bench/{fixtures,run,compare}.py` — fixtures (`.npz` + sha256 manifest), runner (all `get_*`, `[0,1]`-normalised, warmup + reps, timeout, threads=1), comparator (raw timings table).
- `.github/workflows/benchmark.yml` + `scripts/run_benchmark.sh` — two-job workflow (tokenless build runs PR code; privileged report posts the comment). **The harness comes from `main`** and the PR head is fetched as a worktree, so any perf PR is benchmarkable without carrying the tooling.

Note: run `nix fmt` before merge for the YAML (dprint).