### PR TITLE
fix(benchmark): install six in the bench env (centrosome's undeclared dep)

### DIFF
--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -27,7 +27,7 @@ vendor_tooling() { # copy main's generator + bench tooling into the head worktre
 
 echo "::group::main env: install, build fixtures, run"
 uv venv "$WORK/venv-main"
-uv pip install --python "$WORK/venv-main/bin/python" -e "$MAIN_DIR"
+uv pip install --python "$WORK/venv-main/bin/python" -e "$MAIN_DIR" six
 "$WORK/venv-main/bin/python" -m cp_measure._bench.fixtures --out "$SHARED" --matrix "$MATRIX"
 "$WORK/venv-main/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/main.json"
 echo "::endgroup::"
@@ -37,7 +37,7 @@ git fetch --no-tags --depth=1 origin "$HEAD_REF"
 git worktree add --detach "$WORK/head" FETCH_HEAD
 vendor_tooling "$WORK/head"
 uv venv "$WORK/venv-head"
-uv pip install --python "$WORK/venv-head/bin/python" -e "$WORK/head"
+uv pip install --python "$WORK/venv-head/bin/python" -e "$WORK/head" six
 "$WORK/venv-head/bin/python" -m cp_measure._bench.run --fixtures "$SHARED" --out "$OUT/head.json"
 echo "::endgroup::"
 


### PR DESCRIPTION
The benchmark run failed on `ModuleNotFoundError: No module named 'six'` (PR #81 run): centrosome imports `six` but doesn't declare it, so a fresh `uv pip install -e .` in the bench venvs omits it.

Fix: add `six` to the two `uv pip install` commands in `run_benchmark.sh` only — it lands in the benchmark's **ephemeral venvs**, exactly like `noxfile.py` already does for the test session. **No change to `pyproject.toml`; not a cp_measure dependency.**