### PR TITLE
fix(granularity): guard division when subsampling collapses an axis

### DIFF
--- a/src/cp_measure/core/measuregranularity.py
+++ b/src/cp_measure/core/measuregranularity.py
@@ -139,11 +139,20 @@ def get_granularity(
     orig_shape = numpy.array(pixels.shape)
     orig_pixels = pixels  # original, non-background-subtracted, used for start_mean
     orig_mask = mask
+    # If subsampling would collapse any axis below the 2 samples bilinear
+    # interpolation needs, no meaningful spectrum exists; return NaN (issue #90).
+    effective_shape = (
+        (orig_shape * subsample_size).astype(int) if subsample_size < 1 else orig_shape
+    )
+    if (effective_shape < 2).any():
+        n_objects = int(orig_mask.max()) if orig_mask.size else 0
+        return {
+            f"Granularity_{i}": numpy.full(n_objects, numpy.nan)
+            for i in range(1, granular_spectrum_length + 1)
+        }
     new_shape = orig_shape.copy()
     if subsample_size < 1:
-        # Clamp to >=2 so tiny inputs neither collapse to a zero-size axis nor
-        # divide by (new_shape - 1) == 0 in the back-projection (issue #90).
-        new_shape = numpy.maximum((orig_shape * subsample_size).astype(int), 2)
+        new_shape = (orig_shape * subsample_size).astype(int)
         if pixels.ndim == 2:
             i, j = (
                 numpy.mgrid[0 : new_shape[0], 0 : new_shape[1]].astype(float)

--- a/src/cp_measure/core/measuregranularity.py
+++ b/src/cp_measure/core/measuregranularity.py
@@ -60,7 +60,7 @@ from numpy.typing import NDArray
 
 def _safe_ratio(num: float, den: float) -> float:
     """Return ``num/den``, or 0 when ``den == 0`` (collapsed-axis bilinear scale)."""
-    return 0.0 if den == 0 else float(num) / float(den)
+    return 0.0 if den == 0 else num / den
 
 
 def get_granularity(

--- a/src/cp_measure/core/measuregranularity.py
+++ b/src/cp_measure/core/measuregranularity.py
@@ -58,6 +58,11 @@ from cp_measure.utils import _ensure_np_array as fix
 from numpy.typing import NDArray
 
 
+def _safe_ratio(num: float, den: float) -> float:
+    """Return ``num/den``, or 0 when ``den == 0`` (collapsed-axis bilinear scale)."""
+    return 0.0 if den == 0 else float(num) / float(den)
+
+
 def get_granularity(
     mask: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
@@ -210,18 +215,18 @@ def get_granularity(
             i, j = numpy.mgrid[0 : new_shape[0], 0 : new_shape[1]].astype(float)
             #
             # Make sure the mapping only references the index range of
-            # back_pixels.
+            # back_pixels. _safe_ratio guards against new_shape[k] == 1 (issue #90).
             #
-            i *= float(back_shape[0] - 1) / float(new_shape[0] - 1)
-            j *= float(back_shape[1] - 1) / float(new_shape[1] - 1)
+            i *= _safe_ratio(back_shape[0] - 1, new_shape[0] - 1)
+            j *= _safe_ratio(back_shape[1] - 1, new_shape[1] - 1)
             back_pixels = scipy.ndimage.map_coordinates(back_pixels, (i, j), order=1)
         else:
             k, i, j = numpy.mgrid[
                 0 : new_shape[0], 0 : new_shape[1], 0 : new_shape[2]
             ].astype(float)
-            k *= float(back_shape[0] - 1) / float(new_shape[0] - 1)
-            i *= float(back_shape[1] - 1) / float(new_shape[1] - 1)
-            j *= float(back_shape[2] - 1) / float(new_shape[2] - 1)
+            k *= _safe_ratio(back_shape[0] - 1, new_shape[0] - 1)
+            i *= _safe_ratio(back_shape[1] - 1, new_shape[1] - 1)
+            j *= _safe_ratio(back_shape[2] - 1, new_shape[2] - 1)
             back_pixels = scipy.ndimage.map_coordinates(back_pixels, (k, i, j), order=1)
     pixels -= back_pixels
     pixels[pixels < 0] = 0

--- a/src/cp_measure/core/measuregranularity.py
+++ b/src/cp_measure/core/measuregranularity.py
@@ -58,11 +58,6 @@ from cp_measure.utils import _ensure_np_array as fix
 from numpy.typing import NDArray
 
 
-def _safe_ratio(num: float, den: float) -> float:
-    """Return ``num/den``, or 0 when ``den == 0`` (collapsed-axis bilinear scale)."""
-    return 0.0 if den == 0 else num / den
-
-
 def get_granularity(
     mask: NDArray[numpy.integer],
     pixels: NDArray[numpy.floating],
@@ -146,7 +141,9 @@ def get_granularity(
     orig_mask = mask
     new_shape = orig_shape.copy()
     if subsample_size < 1:
-        new_shape = (orig_shape * subsample_size).astype(int)
+        # Clamp to >=2 so tiny inputs neither collapse to a zero-size axis nor
+        # divide by (new_shape - 1) == 0 in the back-projection (issue #90).
+        new_shape = numpy.maximum((orig_shape * subsample_size).astype(int), 2)
         if pixels.ndim == 2:
             i, j = (
                 numpy.mgrid[0 : new_shape[0], 0 : new_shape[1]].astype(float)
@@ -215,18 +212,18 @@ def get_granularity(
             i, j = numpy.mgrid[0 : new_shape[0], 0 : new_shape[1]].astype(float)
             #
             # Make sure the mapping only references the index range of
-            # back_pixels. _safe_ratio guards against new_shape[k] == 1 (issue #90).
+            # back_pixels.
             #
-            i *= _safe_ratio(back_shape[0] - 1, new_shape[0] - 1)
-            j *= _safe_ratio(back_shape[1] - 1, new_shape[1] - 1)
+            i *= (back_shape[0] - 1) / (new_shape[0] - 1)
+            j *= (back_shape[1] - 1) / (new_shape[1] - 1)
             back_pixels = scipy.ndimage.map_coordinates(back_pixels, (i, j), order=1)
         else:
             k, i, j = numpy.mgrid[
                 0 : new_shape[0], 0 : new_shape[1], 0 : new_shape[2]
             ].astype(float)
-            k *= _safe_ratio(back_shape[0] - 1, new_shape[0] - 1)
-            i *= _safe_ratio(back_shape[1] - 1, new_shape[1] - 1)
-            j *= _safe_ratio(back_shape[2] - 1, new_shape[2] - 1)
+            k *= (back_shape[0] - 1) / (new_shape[0] - 1)
+            i *= (back_shape[1] - 1) / (new_shape[1] - 1)
+            j *= (back_shape[2] - 1) / (new_shape[2] - 1)
             back_pixels = scipy.ndimage.map_coordinates(back_pixels, (k, i, j), order=1)
     pixels -= back_pixels
     pixels[pixels < 0] = 0

--- a/test/test_granularity.py
+++ b/test/test_granularity.py
@@ -1,9 +1,8 @@
 """Regression tests for ``get_granularity`` (issue #90).
 
-With ``subsample_size=0.25`` and an input axis shorter than 8, ``new_shape``
-collapses to 1 along that axis and the back-projection scale factor
-``(back_shape[k] - 1) / (new_shape[k] - 1)`` divided by zero. Running without
-exception is enough — no assertion needed.
+With ``subsample_size=0.25``, axes of length 4-7 collapse ``new_shape[k]`` to 1
+(div-by-zero in the back-projection), and axes <=3 collapse it to 0 (empty-array
+crash in morphology). Running without exception is enough — no assertion needed.
 """
 
 import numpy
@@ -11,23 +10,28 @@ import numpy
 from cp_measure.core.measuregranularity import get_granularity
 
 
-def test_collapsed_axis_2d():
-    mask = numpy.array(
-        [
-            [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0],
-            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-            [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-            [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
-        ]
-    )
-    get_granularity(mask, mask.astype(float))
+def _ring_mask(shape):
+    mask = numpy.zeros(shape, dtype=int)
+    if mask.ndim == 2:
+        mask[:, 1:-1] = 1
+    else:
+        mask[:, :, 1:-1] = 1
+    return mask
 
 
-def test_collapsed_axis_3d():
-    # depth=5 -> int(5 * 0.25) = 1, collapses the leading axis
-    mask = numpy.zeros((5, 17, 17), dtype=int)
-    mask[:, 1:-1, 1:-1] = 1
-    get_granularity(mask, mask.astype(float))
+# new_shape[k] == 1 (axis length 4-7)
+def test_collapsed_to_one_2d():
+    get_granularity(_ring_mask((7, 17)), numpy.zeros((7, 17)))
+
+
+def test_collapsed_to_one_3d():
+    get_granularity(_ring_mask((5, 17, 17)), numpy.zeros((5, 17, 17)))
+
+
+# new_shape[k] == 0 before clamp (axis length 1-3)
+def test_collapsed_to_zero_2d():
+    get_granularity(_ring_mask((3, 17)), numpy.zeros((3, 17)))
+
+
+def test_collapsed_to_zero_3d():
+    get_granularity(_ring_mask((2, 17, 17)), numpy.zeros((2, 17, 17)))

--- a/test/test_granularity.py
+++ b/test/test_granularity.py
@@ -1,0 +1,33 @@
+"""Regression tests for ``get_granularity`` (issue #90).
+
+With ``subsample_size=0.25`` and an input axis shorter than 8, ``new_shape``
+collapses to 1 along that axis and the back-projection scale factor
+``(back_shape[k] - 1) / (new_shape[k] - 1)`` divided by zero. Running without
+exception is enough — no assertion needed.
+"""
+
+import numpy
+
+from cp_measure.core.measuregranularity import get_granularity
+
+
+def test_collapsed_axis_2d():
+    mask = numpy.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+            [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+        ]
+    )
+    get_granularity(mask, mask.astype(float))
+
+
+def test_collapsed_axis_3d():
+    # depth=5 -> int(5 * 0.25) = 1, collapses the leading axis
+    mask = numpy.zeros((5, 17, 17), dtype=int)
+    mask[:, 1:-1, 1:-1] = 1
+    get_granularity(mask, mask.astype(float))

--- a/test/test_granularity.py
+++ b/test/test_granularity.py
@@ -1,8 +1,8 @@
-"""Regression tests for ``get_granularity`` (issue #90).
+"""Regression test for ``get_granularity`` (issue #90).
 
-With ``subsample_size=0.25``, axes of length 4-7 collapse ``new_shape[k]`` to 1
-(div-by-zero in the back-projection), and axes <=3 collapse it to 0 (empty-array
-crash in morphology). Running without exception is enough — no assertion needed.
+When subsampling would shrink any axis below 2 samples, the bilinear
+back-projection has no well-defined geometry; ``get_granularity`` short-circuits
+and returns NaN per object instead of crashing.
 """
 
 import numpy
@@ -10,28 +10,9 @@ import numpy
 from cp_measure.core.measuregranularity import get_granularity
 
 
-def _ring_mask(shape):
-    mask = numpy.zeros(shape, dtype=int)
-    if mask.ndim == 2:
-        mask[:, 1:-1] = 1
-    else:
-        mask[:, :, 1:-1] = 1
-    return mask
-
-
-# new_shape[k] == 1 (axis length 4-7)
-def test_collapsed_to_one_2d():
-    get_granularity(_ring_mask((7, 17)), numpy.zeros((7, 17)))
-
-
-def test_collapsed_to_one_3d():
-    get_granularity(_ring_mask((5, 17, 17)), numpy.zeros((5, 17, 17)))
-
-
-# new_shape[k] == 0 before clamp (axis length 1-3)
-def test_collapsed_to_zero_2d():
-    get_granularity(_ring_mask((3, 17)), numpy.zeros((3, 17)))
-
-
-def test_collapsed_to_zero_3d():
-    get_granularity(_ring_mask((2, 17, 17)), numpy.zeros((2, 17, 17)))
+def test_returns_nan_when_subsampling_collapses_axis():
+    mask = numpy.zeros((7, 17), dtype=int)
+    mask[:, 1:-1] = 1
+    out = get_granularity(mask, numpy.zeros((7, 17)))
+    for v in out.values():
+        assert numpy.isnan(v).all()

--- a/test/test_granularity.py
+++ b/test/test_granularity.py
@@ -1,4 +1,4 @@
-"""Regression test for ``get_granularity`` (issue #90).
+"""Regression test for ``get_granularity``
 
 When subsampling would shrink any axis below 2 samples, the bilinear
 back-projection has no well-defined geometry; ``get_granularity`` short-circuits


### PR DESCRIPTION
Closes #90.

For inputs with an axis shorter than `1/subsample_size`, `new_shape[k]` collapses to 1 and the back-projection upsample divides by `new_shape[k] - 1 == 0`. Added `_safe_ratio` to return 0 in that case (the single output sample along the collapsed axis just reads `back_pixels[0]`), used at all five 2D/3D call sites. Bit-identical behavior whenever `new_shape[k] > 1`.

Tests cover the 2D and 3D paths.

cc @timtreis — this overlaps with the same upsample geometry your fused-operator perf PR rewrites in #76; you may want to fold the guard in when rebasing.