### PR TITLE
perf(overlap): drop dead TP/FN/FP/TN pixel-map computation (~3x)

### DIFF
--- a/src/cp_measure/multimask/measureobjectoverlap.py
+++ b/src/cp_measure/multimask/measureobjectoverlap.py
@@ -111,24 +111,6 @@ def nan_divide(
     return float(numerator) / float(denominator)
 
 
-def subscripts(
-    condition1: numpy.ndarray,
-    condition2: numpy.ndarray,
-    GT_pixels: numpy.ndarray,
-    ID_pixels: numpy.ndarray,
-) -> list:
-    x1, y1 = numpy.where(GT_pixels == condition1)
-    x2, y2 = numpy.where(ID_pixels == condition2)
-    mask = set(zip(x1, y1)) & set(zip(x2, y2))
-    return list(mask)
-
-
-def maskimg(mask, img):
-    for ea in mask:
-        img[ea] = 1
-    return img
-
-
 def measureobjectoverlap(
     masks1: numpy.ndarray,
     masks2: numpy.ndarray,
@@ -385,20 +367,6 @@ def measureobjectoverlap(
         for k, v in measurement_value.items():
             results[f"{C_IMAGE_OVERLAP}_{k}"] = v
 
-        TP_mask = subscripts(1, 1, GT_pixels, ID_pixels)
-        FN_mask = subscripts(1, 0, GT_pixels, ID_pixels)
-        FP_mask = subscripts(0, 1, GT_pixels, ID_pixels)
-        TN_mask = subscripts(0, 0, GT_pixels, ID_pixels)
-
-        TP_pixels = numpy.zeros((xGT, yGT))
-        FN_pixels = numpy.zeros((xGT, yGT))
-        FP_pixels = numpy.zeros((xGT, yGT))
-        TN_pixels = numpy.zeros((xGT, yGT))
-
-        TP_pixels = maskimg(TP_mask, TP_pixels)
-        FN_pixels = maskimg(FN_mask, FN_pixels)
-        FP_pixels = maskimg(FP_mask, FP_pixels)
-        TN_pixels = maskimg(TN_mask, TN_pixels)
         if wants_emd:
             emd = compute_emd(
                 objects_ID,


### PR DESCRIPTION
`measureobjectoverlap` computed TP/FN/FP/TN pixel maps (via the `subscripts()` set-intersection + `maskimg()` per-pixel-assignment helpers) and then **never used them** — the function returns `results`, which only holds the overlap measurements and the optional EMD. The four maps are assigned and discarded: never read, never added to `results`, never returned.

They're a verbatim carry-over from CellProfiler's MeasureObjectOverlap (which renders TP/FP/FN/TN as overlay **images**); cp_measure returns a feature dict, so they have no consumer here. The `set(zip(...)) & set(zip(...))` intersection + per-pixel Python loop was ~2/3 of the function's runtime.

Deleting the dead block and the now-unused `subscripts()`/`maskimg()` helpers is **output-identical** and **~3× faster** end-to-end (1024px/64 objects: 3140ms → 1060ms, 2.96×; verified `allclose`, all 19 `test_multimask.py` tests pass).

Net: −32 lines, no behavior change.
