### PR TITLE
perf(core): colocalization + contiguity micro-optimizations

### DIFF
--- a/src/cp_measure/core/measurecolocalization.py
+++ b/src/cp_measure/core/measurecolocalization.py
@@ -84,7 +84,6 @@ import numpy
 from numpy.typing import NDArray
 import scipy.ndimage
 import scipy.stats
-from scipy.linalg import lstsq
 
 M_IMAGES = "Across entire image"
 M_OBJECTS = "Within objects"
@@ -155,8 +154,9 @@ def _pearson_pair(
     fi: NDArray[numpy.floating], si: NDArray[numpy.floating]
 ) -> tuple[float, float]:
     corr = numpy.corrcoef(fi, si)[0, 1]
-    coeffs = lstsq(numpy.array((fi, numpy.ones_like(fi))).transpose(), si)[0]
-    return float(corr), float(coeffs[0])
+    # OLS slope of si on fi is cov/var — avoids a per-object lstsq + design-matrix build.
+    slope = numpy.cov(fi, si)[0, 1] / numpy.var(fi, ddof=1)
+    return float(corr), float(slope)
 
 
 def _manders_pair(
@@ -384,13 +384,15 @@ def linear_costes(
     """
     i_step = 1 / scale_max
     non_zero = (fi > 0) | (si > 0)
-    xvar = numpy.var(fi[non_zero], axis=0, ddof=1)
-    yvar = numpy.var(si[non_zero], axis=0, ddof=1)
+    fz = fi[non_zero]
+    sz = si[non_zero]
+    xvar = numpy.var(fz, axis=0, ddof=1)
+    yvar = numpy.var(sz, axis=0, ddof=1)
 
-    xmean = numpy.mean(fi[non_zero], axis=0)
-    ymean = numpy.mean(si[non_zero], axis=0)
+    xmean = numpy.mean(fz, axis=0)
+    ymean = numpy.mean(sz, axis=0)
 
-    z = fi[non_zero] + si[non_zero]
+    z = fz + sz
     zvar = numpy.var(z, axis=0, ddof=1)
 
     covar = 0.5 * (zvar - (xvar + yvar))
@@ -464,13 +466,15 @@ def bisection_costes(
     """
 
     non_zero = (fi > 0) | (si > 0)
-    xvar = numpy.var(fi[non_zero], axis=0, ddof=1)
-    yvar = numpy.var(si[non_zero], axis=0, ddof=1)
+    fz = fi[non_zero]
+    sz = si[non_zero]
+    xvar = numpy.var(fz, axis=0, ddof=1)
+    yvar = numpy.var(sz, axis=0, ddof=1)
 
-    xmean = numpy.mean(fi[non_zero], axis=0)
-    ymean = numpy.mean(si[non_zero], axis=0)
+    xmean = numpy.mean(fz, axis=0)
+    ymean = numpy.mean(sz, axis=0)
 
-    z = fi[non_zero] + si[non_zero]
+    z = fz + sz
     zvar = numpy.var(z, axis=0, ddof=1)
 
     covar = 0.5 * (zvar - (xvar + yvar))

--- a/src/cp_measure/core/measureobjectsizeshape.py
+++ b/src/cp_measure/core/measureobjectsizeshape.py
@@ -632,7 +632,7 @@ def get_sizeshape(
                 ]
 
     labels = masks
-    nobjects = (numpy.unique(masks) > 0).sum()
+    nobjects = int(masks.max())  # contiguous 1..N (see cp_measure._sanitize)
     results: dict[str, NDArray[numpy.floating]] = {}
     if labels.ndim == 2:
         props = skimage.measure.regionprops_table(
@@ -1037,8 +1037,7 @@ def get_feret(
     if masks.ndim == 3:
         return {}
     ijv = masks_to_ijv(masks)
-    indices = numpy.unique(ijv[:, 2])
-    indices = indices[indices > 0]
+    indices = numpy.arange(1, int(masks.max()) + 1)  # contiguous 1..N
     chulls, chull_counts = centrosome.cpmorphology.convex_hull_ijv(ijv, indices)
     #
     # Feret diameter

--- a/src/cp_measure/utils.py
+++ b/src/cp_measure/utils.py
@@ -48,8 +48,9 @@ def labels_to_binmasks(masks: numpy.ndarray) -> numpy.ndarray:
 
     Returns a list of binary masks.
     """
-    labels = numpy.unique(masks)
-    labels = labels[labels > 0]
+    labels = numpy.arange(
+        1, int(masks.max()) + 1
+    )  # contiguous 1..N (see cp_measure._sanitize)
     return masks == labels.reshape((-1,) + (1,) * masks.ndim)
 
 


### PR DESCRIPTION
Five small, output-preserving speedups found by an end-to-end perf audit (measured single-threaded, each verified `allclose` vs baseline).

**Colocalization**
- `_pearson_pair`: OLS slope as `cov/var` instead of a per-object `scipy.linalg.lstsq` + design-matrix build — **~1.15–1.21×** on `get_correlation_pearson` (slope matches `lstsq` to ~1e-6, Pearson *r* unchanged). Drops the now-unused `lstsq` import.
- Costes (linear + bisection): extract `fi[non_zero]`/`si[non_zero]` once instead of re-slicing 4×/3× per object — **~1.07–1.36×** on `get_correlation_costes`, bit-identical.

**Contiguity** (labels are 1..N by contract, `cp_measure._sanitize`)
- `get_sizeshape`: `nobjects = int(masks.max())` instead of `(numpy.unique(masks) > 0).sum()` — ~1.0–1.19× (size-dependent), bit-identical.
- `get_feret`: `numpy.arange(1, masks.max()+1)` instead of `numpy.unique(ijv[:, 2])` — ~1.03–1.18×, bit-identical.
- `labels_to_binmasks`: `arange` instead of `numpy.unique(masks)` — drops a full-image sort, bit-identical under the contract.