### PR TITLE
ci(benchmark): measure the numba backend on numba-targeting PRs

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -159,6 +159,7 @@ def compare(
     commit: str = "",
     base_name: str = "main",
     head_name: str = "head",
+    filter_base: dict | None = None,
 ) -> str:
     groups: dict[tuple, list[str]] = {}
     for e in head["cells"]:
@@ -166,6 +167,10 @@ def compare(
     sizes = sorted({s for s, _ in groups})
     counts = sorted({n for _, n in groups})
     br, hr = base["results"], head["results"]
+    # A function is *shown* when it moved vs filter_base (default: the displayed base), but the
+    # printed speedup is always base/head. This lets the numba table pick which functions THIS PR
+    # changed (filter on numba@main) while displaying the total speedup over numpy (base=numpy@main).
+    fr = filter_base["results"] if filter_base else br
 
     ref = f"`{commit[:7]}`" if commit else "PR head"
     out = [
@@ -178,15 +183,17 @@ def compare(
     lo = 1.0 / AFFECTED  # a cell at or below this is a regression worth reporting
     affected = []  # (function, {(size, count): speedup})
     for fn in sorted(hr):
-        grid, speedups = {}, []
+        grid, moves = {}, []
         for size in sizes:
             for n in counts:
-                m = _median_ms(br.get(fn, {}), groups.get((size, n), []))
-                h = _median_ms(hr[fn], groups.get((size, n), []))
+                keys = groups.get((size, n), [])
+                m = _median_ms(br.get(fn, {}), keys)
+                h = _median_ms(hr[fn], keys)
                 grid[(size, n)] = (m / h) if (m and h) else None
-                if grid[(size, n)]:
-                    speedups.append(grid[(size, n)])
-        if speedups and (max(speedups) >= AFFECTED or min(speedups) <= lo):
+                f = _median_ms(fr.get(fn, {}), keys)
+                if f and h:
+                    moves.append(f / h)  # movement vs filter_base decides inclusion
+        if moves and (max(moves) >= AFFECTED or min(moves) <= lo):
             affected.append((fn, grid))
 
     if not affected:
@@ -222,6 +229,7 @@ def main(argv=None) -> int:
     c.add_argument("--commit", default="")
     c.add_argument("--base-name", default="main")
     c.add_argument("--head-name", default="head")
+    c.add_argument("--filter-base", default=None)
     c.add_argument("--md")
     a = p.parse_args(argv)
     if a.cmd == "run":
@@ -233,6 +241,7 @@ def main(argv=None) -> int:
             a.commit,
             a.base_name,
             a.head_name,
+            json.loads(Path(a.filter_base).read_text()) if a.filter_base else None,
         )
         (Path(a.md).write_text(md) if a.md else print(md))
     return 0

--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -117,7 +117,11 @@ def _time(fn, args) -> dict:
     return {"status": "ok", "reps": reps}
 
 
-def run(out_path: str):
+def run(out_path: str, accelerator: str | None = None):
+    if accelerator:
+        import cp_measure
+
+        cp_measure.set_accelerator(accelerator)
     funcs = _functions()
     cells, results = [], {name: {} for name, _, _ in funcs}
     for size in MATRIX["sizes"]:
@@ -149,7 +153,13 @@ def _median_ms(results_for_fn: dict, keys: list[str]):
     return statistics.median(times) * 1e3 if times else None
 
 
-def compare(base: dict, head: dict, commit: str = "") -> str:
+def compare(
+    base: dict,
+    head: dict,
+    commit: str = "",
+    base_name: str = "main",
+    head_name: str = "head",
+) -> str:
     groups: dict[tuple, list[str]] = {}
     for e in head["cells"]:
         groups.setdefault((e["size"], e["n_objects"]), []).append(e["key"])
@@ -159,9 +169,9 @@ def compare(base: dict, head: dict, commit: str = "") -> str:
 
     ref = f"`{commit[:7]}`" if commit else "PR head"
     out = [
-        f"### Benchmark — {ref} vs `main`",
+        f"### Benchmark — {ref}: `{head_name}` vs `{base_name}`",
         "",
-        f"`speedup = main/head` (>1 faster, <1 slower) · median per cell · "
+        f"`speedup = {base_name}/{head_name}` (>1 faster, <1 slower) · median per cell · "
         f"showing functions that moved ≥{AFFECTED:.2f}× either way",
     ]
 
@@ -205,19 +215,24 @@ def main(argv=None) -> int:
     sub = p.add_subparsers(dest="cmd", required=True)
     r = sub.add_parser("run")
     r.add_argument("--out", required=True)
+    r.add_argument("--accelerator", default=None)
     c = sub.add_parser("compare")
     c.add_argument("--base", required=True)
     c.add_argument("--head", required=True)
     c.add_argument("--commit", default="")
+    c.add_argument("--base-name", default="main")
+    c.add_argument("--head-name", default="head")
     c.add_argument("--md")
     a = p.parse_args(argv)
     if a.cmd == "run":
-        run(a.out)
+        run(a.out, a.accelerator)
     else:
         md = compare(
             json.loads(Path(a.base).read_text()),
             json.loads(Path(a.head).read_text()),
             a.commit,
+            a.base_name,
+            a.head_name,
         )
         (Path(a.md).write_text(md) if a.md else print(md))
     return 0

--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -52,9 +52,12 @@ echo "::endgroup::"
   --base "$OUT/main.json" --head "$OUT/head.json" --commit "$COMMIT" \
   --base-name main --head-name head --md "$OUT/table.md"
 
-# numba PRs: the numpy table above tracks the numpy backend head-vs-main; this one tracks the numba
-# backend head-vs-main (numba@main is the current baseline — un-ported features fall back to numpy —
-# so this measures how far this PR moves the numba backend forward).
+# numba PRs: the numpy table above tracks the numpy backend head-vs-main. This one times the numba
+# backend head-vs-main and reports the speedup vs numpy main for the features THIS PR changes in
+# numba. --filter-base picks those features (head-numba differs from numba@main), while --base makes
+# the printed speedup numpy@main/numba-head. numba@main falls back to numpy for un-ported features,
+# so for a greenfield feature this IS the whole story; the day a follow-up PR improves an existing
+# numba impl, add a second table with --base main-numba.json for the incremental gain.
 # The numba backend is optional: a failure to install or run it (e.g. main not yet carrying the
 # backend, or a wheel/arch gap) must NOT sink the numpy table — the sticky-comment step only runs
 # on success. Run the pass in a subshell so any failure is caught here, not propagated by `set -e`.
@@ -64,11 +67,12 @@ if [ "$NUMBA" = 1 ]; then
       "$WORK/venv-head/bin/python" "$BENCH" run --accelerator numba --out "$OUT/head-numba.json" &&
       "$WORK/venv-main/bin/python" "$BENCH" run --accelerator numba --out "$OUT/main-numba.json" &&
       "$WORK/venv-head/bin/python" "$BENCH" compare \
-        --base "$OUT/main-numba.json" --head "$OUT/head-numba.json" --commit "$COMMIT" \
-        --base-name "numba main" --head-name "numba head" --md "$OUT/table-numba.md"
+        --base "$OUT/main.json" --filter-base "$OUT/main-numba.json" --head "$OUT/head-numba.json" \
+        --commit "$COMMIT" --base-name "numpy main" --head-name "numba head" \
+        --md "$OUT/table-numba.md"
     ); then
-    # Append only when the numba backend actually moved something, to avoid a misleading
-    # "numba tested" section on PRs that touch bulk.py but not the numba path.
+    # Append when this PR moved a numba feature. A bulk.py-only PR that touches no numba path moves
+    # nothing here, so nothing misleading is appended.
     grep -q "No function moved" "$OUT/table-numba.md" ||
       { printf '\n\n'; cat "$OUT/table-numba.md"; } >> "$OUT/table.md"
   else

--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -23,7 +23,7 @@ trap 'git worktree remove --force "$WORK/main" 2>/dev/null || true; rm -rf "$WOR
 git fetch --no-tags origin main
 BASE="$(git merge-base HEAD origin/main || echo origin/main)"
 NUMBA=0
-if git diff --name-only "$BASE" HEAD | grep -qE '^src/cp_measure/(core/numba/|bulk\.py)$'; then
+if git diff --name-only "$BASE" HEAD | grep -qE '^src/cp_measure/core/numba/|^src/cp_measure/bulk\.py$'; then
   NUMBA=1
 fi
 echo "numba-targeting PR: $NUMBA"

--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Install the PR head and main into separate venvs and run benchmark.py (from this checkout) in
 # each, then compare. Each run regenerates the same seeded inputs, so nothing is shared on disk.
+# When the PR targets the numba backend, additionally times numba-vs-numpy on the head build.
 # Usage: run_benchmark.sh <out-dir> <head-commit-sha>
 set -euo pipefail
 
@@ -17,15 +18,26 @@ BENCH="$HEAD_DIR/.github/scripts/benchmark.py"
 mkdir -p "$OUT"
 trap 'git worktree remove --force "$WORK/main" 2>/dev/null || true; rm -rf "$WORK"' EXIT
 
+# Detect whether this PR targets the numba backend: does it touch a numba implementation or the
+# dispatch registry? If so, install the [numba] extra on head and add a numba-vs-numpy pass below.
+git fetch --no-tags origin main
+BASE="$(git merge-base HEAD origin/main || echo origin/main)"
+NUMBA=0
+if git diff --name-only "$BASE" HEAD | grep -qE '^src/cp_measure/(core/numba/|bulk\.py)$'; then
+  NUMBA=1
+fi
+echo "numba-targeting PR: $NUMBA"
+HEAD_EXTRA=""
+[ "$NUMBA" = 1 ] && HEAD_EXTRA="[numba]"
+
 # six is a centrosome runtime dep not declared in its metadata; install it into the bench venvs only.
 echo "::group::PR head env"
 uv venv "$WORK/venv-head"
-uv pip install --python "$WORK/venv-head/bin/python" -e "$HEAD_DIR" six
+uv pip install --python "$WORK/venv-head/bin/python" -e "${HEAD_DIR}${HEAD_EXTRA}" six
 "$WORK/venv-head/bin/python" "$BENCH" run --out "$OUT/head.json"
 echo "::endgroup::"
 
 echo "::group::main env"
-git fetch --no-tags --depth=1 origin main
 git worktree add --detach "$WORK/main" origin/main
 uv venv "$WORK/venv-main"
 uv pip install --python "$WORK/venv-main/bin/python" -e "$WORK/main" six
@@ -34,4 +46,17 @@ echo "::endgroup::"
 
 "$WORK/venv-head/bin/python" "$BENCH" compare \
   --base "$OUT/main.json" --head "$OUT/head.json" --commit "$COMMIT" --md "$OUT/table.md"
+
+# numba PRs: numpy-vs-numpy above catches regressions; this pass shows the actual backend speedup,
+# numba vs numpy on the same head build (independent of what is merged on main).
+if [ "$NUMBA" = 1 ]; then
+  echo "::group::numba head run"
+  "$WORK/venv-head/bin/python" "$BENCH" run --accelerator numba --out "$OUT/head-numba.json"
+  "$WORK/venv-head/bin/python" "$BENCH" compare \
+    --base "$OUT/head.json" --head "$OUT/head-numba.json" --commit "$COMMIT" \
+    --base-name numpy --head-name numba --md "$OUT/table-numba.md"
+  { printf '\n\n'; cat "$OUT/table-numba.md"; } >> "$OUT/table.md"
+  echo "::endgroup::"
+fi
+
 cat "$OUT/table.md"

--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -23,7 +23,10 @@ trap 'git worktree remove --force "$WORK/main" 2>/dev/null || true; rm -rf "$WOR
 git fetch --no-tags origin main
 BASE="$(git merge-base HEAD origin/main || echo origin/main)"
 NUMBA=0
-if git diff --name-only "$BASE" HEAD | grep -qE '^src/cp_measure/core/numba/|^src/cp_measure/bulk\.py$'; then
+# Capture the diff first, then grep the string: `git … | grep -q` under `pipefail` can report the
+# pipe's SIGPIPE (141) when grep exits early on a match, spuriously flipping detection to 0.
+CHANGED="$(git diff --name-only "$BASE" HEAD)"
+if grep -qE '^src/cp_measure/core/numba/|^src/cp_measure/bulk\.py$' <<< "$CHANGED"; then
   NUMBA=1
 fi
 echo "numba-targeting PR: $NUMBA"
@@ -52,14 +55,26 @@ echo "::endgroup::"
 # numba PRs: the numpy table above tracks the numpy backend head-vs-main; this one tracks the numba
 # backend head-vs-main (numba@main is the current baseline — un-ported features fall back to numpy —
 # so this measures how far this PR moves the numba backend forward).
+# The numba backend is optional: a failure to install or run it (e.g. main not yet carrying the
+# backend, or a wheel/arch gap) must NOT sink the numpy table — the sticky-comment step only runs
+# on success. Run the pass in a subshell so any failure is caught here, not propagated by `set -e`.
 if [ "$NUMBA" = 1 ]; then
   echo "::group::numba runs"
-  "$WORK/venv-head/bin/python" "$BENCH" run --accelerator numba --out "$OUT/head-numba.json"
-  "$WORK/venv-main/bin/python" "$BENCH" run --accelerator numba --out "$OUT/main-numba.json"
-  "$WORK/venv-head/bin/python" "$BENCH" compare \
-    --base "$OUT/main-numba.json" --head "$OUT/head-numba.json" --commit "$COMMIT" \
-    --base-name "numba main" --head-name "numba head" --md "$OUT/table-numba.md"
-  { printf '\n\n'; cat "$OUT/table-numba.md"; } >> "$OUT/table.md"
+  if (
+      "$WORK/venv-head/bin/python" "$BENCH" run --accelerator numba --out "$OUT/head-numba.json" &&
+      "$WORK/venv-main/bin/python" "$BENCH" run --accelerator numba --out "$OUT/main-numba.json" &&
+      "$WORK/venv-head/bin/python" "$BENCH" compare \
+        --base "$OUT/main-numba.json" --head "$OUT/head-numba.json" --commit "$COMMIT" \
+        --base-name "numba main" --head-name "numba head" --md "$OUT/table-numba.md"
+    ); then
+    # Append only when the numba backend actually moved something, to avoid a misleading
+    # "numba tested" section on PRs that touch bulk.py but not the numba path.
+    grep -q "No function moved" "$OUT/table-numba.md" ||
+      { printf '\n\n'; cat "$OUT/table-numba.md"; } >> "$OUT/table.md"
+  else
+    printf '\n\n_numba benchmark failed for this PR; the numpy results above are unaffected._\n' \
+      >> "$OUT/table.md"
+  fi
   echo "::endgroup::"
 fi
 

--- a/.github/scripts/run_benchmark.sh
+++ b/.github/scripts/run_benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install the PR head and main into separate venvs and run benchmark.py (from this checkout) in
 # each, then compare. Each run regenerates the same seeded inputs, so nothing is shared on disk.
-# When the PR targets the numba backend, additionally times numba-vs-numpy on the head build.
+# When the PR targets the numba backend, also times the numba backend head-vs-main.
 # Usage: run_benchmark.sh <out-dir> <head-commit-sha>
 set -euo pipefail
 
@@ -19,7 +19,7 @@ mkdir -p "$OUT"
 trap 'git worktree remove --force "$WORK/main" 2>/dev/null || true; rm -rf "$WORK"' EXIT
 
 # Detect whether this PR targets the numba backend: does it touch a numba implementation or the
-# dispatch registry? If so, install the [numba] extra on head and add a numba-vs-numpy pass below.
+# dispatch registry? If so, install [numba] on both venvs and add a numba head-vs-main pass below.
 git fetch --no-tags origin main
 BASE="$(git merge-base HEAD origin/main || echo origin/main)"
 NUMBA=0
@@ -27,34 +27,38 @@ if git diff --name-only "$BASE" HEAD | grep -qE '^src/cp_measure/(core/numba/|bu
   NUMBA=1
 fi
 echo "numba-targeting PR: $NUMBA"
-HEAD_EXTRA=""
-[ "$NUMBA" = 1 ] && HEAD_EXTRA="[numba]"
+# On a numba PR both venvs get [numba] so each backend can be timed head-vs-its-own-main.
+EXTRA=""
+[ "$NUMBA" = 1 ] && EXTRA="[numba]"
 
 # six is a centrosome runtime dep not declared in its metadata; install it into the bench venvs only.
 echo "::group::PR head env"
 uv venv "$WORK/venv-head"
-uv pip install --python "$WORK/venv-head/bin/python" -e "${HEAD_DIR}${HEAD_EXTRA}" six
+uv pip install --python "$WORK/venv-head/bin/python" -e "${HEAD_DIR}${EXTRA}" six
 "$WORK/venv-head/bin/python" "$BENCH" run --out "$OUT/head.json"
 echo "::endgroup::"
 
 echo "::group::main env"
 git worktree add --detach "$WORK/main" origin/main
 uv venv "$WORK/venv-main"
-uv pip install --python "$WORK/venv-main/bin/python" -e "$WORK/main" six
+uv pip install --python "$WORK/venv-main/bin/python" -e "${WORK}/main${EXTRA}" six
 "$WORK/venv-main/bin/python" "$BENCH" run --out "$OUT/main.json"
 echo "::endgroup::"
 
 "$WORK/venv-head/bin/python" "$BENCH" compare \
-  --base "$OUT/main.json" --head "$OUT/head.json" --commit "$COMMIT" --md "$OUT/table.md"
+  --base "$OUT/main.json" --head "$OUT/head.json" --commit "$COMMIT" \
+  --base-name main --head-name head --md "$OUT/table.md"
 
-# numba PRs: numpy-vs-numpy above catches regressions; this pass shows the actual backend speedup,
-# numba vs numpy on the same head build (independent of what is merged on main).
+# numba PRs: the numpy table above tracks the numpy backend head-vs-main; this one tracks the numba
+# backend head-vs-main (numba@main is the current baseline — un-ported features fall back to numpy —
+# so this measures how far this PR moves the numba backend forward).
 if [ "$NUMBA" = 1 ]; then
-  echo "::group::numba head run"
+  echo "::group::numba runs"
   "$WORK/venv-head/bin/python" "$BENCH" run --accelerator numba --out "$OUT/head-numba.json"
+  "$WORK/venv-main/bin/python" "$BENCH" run --accelerator numba --out "$OUT/main-numba.json"
   "$WORK/venv-head/bin/python" "$BENCH" compare \
-    --base "$OUT/head.json" --head "$OUT/head-numba.json" --commit "$COMMIT" \
-    --base-name numpy --head-name numba --md "$OUT/table-numba.md"
+    --base "$OUT/main-numba.json" --head "$OUT/head-numba.json" --commit "$COMMIT" \
+    --base-name "numba main" --head-name "numba head" --md "$OUT/table-numba.md"
   { printf '\n\n'; cat "$OUT/table-numba.md"; } >> "$OUT/table.md"
   echo "::endgroup::"
 fi


### PR DESCRIPTION
## Problem

The PR benchmark only ever timed the **numpy** backend: `benchmark.py` never selected an accelerator and `run_benchmark.sh` never installed the `[numba]` extra. So numba backend PRs (#56, #58, #60, #62, #63, #64, #65, #78) report "no function moved" — the benchmark can't see what they change.

(Numba *correctness* already runs in CI via nox. This only closes the timing gap.)

## Change

Detect a numba-targeting PR (diff vs merge-base touches `src/cp_measure/core/numba/` or `src/cp_measure/bulk.py`). When it does, install `[numba]` on both venvs and add a second table timing the numba backend head-vs-main. Non-numba PRs are unchanged.

The sticky comment then carries two tables:
- **numpy** head vs main — existing regression check on the default backend.
- **numba** head vs main — `numba@main` is the baseline (un-ported features fall back to numpy), so a greenfield backend shows its full speedup and a follow-up shows the incremental gain.

### Files
- `benchmark.py` — `run` gains `--accelerator` (calls `set_accelerator` before timing); `compare` gains `--base-name`/`--head-name` for the heading and `speedup = base/head`.
- `run_benchmark.sh` — detection, conditional `[numba]` install on both venvs, numba head-vs-main pass.

## Verification
- `py_compile` + `bash -n` pass; `ruff format --check` clean.
- Detection fires on #56 (granularity), not #77 (numpy-only perf).
- Real `[numba]` run: numba pass dispatches correctly (intensity 1.74× on main, the only ported feature); numpy path unchanged.
